### PR TITLE
Adding a database ID to the included sequences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ data/out/
 .atom*
 .ensime*
 .idea*
+
+*.fasta
+*.tsv

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,11 @@ name          := "db.rna16s"
 organization  := "era7bio"
 description   := "db.rna16s project"
 
+resolvers := Seq(
+  "Era7 private maven releases"  at s3("private.releases.era7.com").toHttps(s3region.value.toString),
+  "Era7 private maven snapshots" at s3("private.snapshots.era7.com").toHttps(s3region.value.toString)
+) ++ resolvers.value
+
 bucketSuffix  := "era7.com"
 
 libraryDependencies ++= Seq(
@@ -12,7 +17,7 @@ libraryDependencies ++= Seq(
   "ohnosequences" %% "statika"         % "2.0.0-M5",
   "ohnosequences" %% "aws-scala-tools" % "0.16.0",
 
-  "era7"          %% "defaults"   % "0.1.0",
+  "era7"          %% "defaults"   % "0.2.0-SNAPSHOT",
 
   "ohnosequences-bundles" %% "blast" % "0.3.0",
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ bucketSuffix  := "era7.com"
 
 libraryDependencies ++= Seq(
   "ohnosequences" %% "fastarious"      % "0.5.2",
-  "ohnosequences" %% "blast-api"       % "0.6.2",
+  "ohnosequences" %% "blast-api"       % "0.7.0",
   "ohnosequences" %% "statika"         % "2.0.0-M5",
   "ohnosequences" %% "aws-scala-tools" % "0.16.0",
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ libraryDependencies ++= Seq(
   "ohnosequences" %% "blast-api"       % "0.6.2",
   "ohnosequences" %% "statika"         % "2.0.0-M5",
   "ohnosequences" %% "aws-scala-tools" % "0.16.0",
-  
+
   "era7"          %% "defaults"   % "0.1.0",
 
   "ohnosequences-bundles" %% "blast" % "0.3.0",
@@ -19,4 +19,18 @@ libraryDependencies ++= Seq(
   "com.github.tototoshi" %% "scala-csv" % "1.2.2",
 
   "org.scalatest" %% "scalatest" % "2.2.6" % Test
+)
+
+
+fatArtifactSettings
+
+enablePlugins(BuildInfoPlugin)
+buildInfoPackage := "generated.metadata"
+buildInfoObject  := name.value.split("""\W""").map(_.capitalize).mkString
+buildInfoOptions := Seq(BuildInfoOption.Traits("ohnosequences.statika.AnyArtifactMetadata"))
+buildInfoKeys    := Seq[BuildInfoKey](
+  organization,
+  version,
+  "artifact" -> name.value.toLowerCase,
+  "artifactUrl" -> fatArtifactUrl.value
 )

--- a/build.sbt
+++ b/build.sbt
@@ -7,10 +7,11 @@ description   := "db.rna16s project"
 bucketSuffix  := "era7.com"
 
 libraryDependencies ++= Seq(
-  "ohnosequences" %% "fastarious" % "0.5.1",
-  "ohnosequences" %% "blast-api"  % "0.5.1",
+  "ohnosequences" %% "fastarious" % "0.5.2",
+  "ohnosequences" %% "blast-api"  % "0.6.2",
   "ohnosequences" %% "statika"    % "2.0.0-M5",
   "era7"          %% "defaults"   % "0.1.0",
+  "ohnosequences-bundles" %% "blast" % "0.3.0",
   "com.github.tototoshi" %% "scala-csv" % "1.2.2",
   "org.scalatest" %% "scalatest" % "2.2.6" % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -7,11 +7,16 @@ description   := "db.rna16s project"
 bucketSuffix  := "era7.com"
 
 libraryDependencies ++= Seq(
-  "ohnosequences" %% "fastarious" % "0.5.2",
-  "ohnosequences" %% "blast-api"  % "0.6.2",
-  "ohnosequences" %% "statika"    % "2.0.0-M5",
+  "ohnosequences" %% "fastarious"      % "0.5.1",
+  "ohnosequences" %% "blast-api"       % "0.6.2",
+  "ohnosequences" %% "statika"         % "2.0.0-M5",
+  "ohnosequences" %% "aws-scala-tools" % "0.16.0",
+  
   "era7"          %% "defaults"   % "0.1.0",
+
   "ohnosequences-bundles" %% "blast" % "0.3.0",
+
   "com.github.tototoshi" %% "scala-csv" % "1.2.2",
+
   "org.scalatest" %% "scalatest" % "2.2.6" % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ description   := "db.rna16s project"
 bucketSuffix  := "era7.com"
 
 libraryDependencies ++= Seq(
-  "ohnosequences" %% "fastarious"      % "0.5.1",
+  "ohnosequences" %% "fastarious"      % "0.5.2",
   "ohnosequences" %% "blast-api"       % "0.6.2",
   "ohnosequences" %% "statika"         % "2.0.0-M5",
   "ohnosequences" %% "aws-scala-tools" % "0.16.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 resolvers += "Era7 maven releases" at "https://s3-eu-west-1.amazonaws.com/releases.era7.com"
 
 addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.7.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.5.0")

--- a/src/main/scala/blastDB.scala
+++ b/src/main/scala/blastDB.scala
@@ -2,7 +2,7 @@ package era7bio.db
 
 import ohnosequences.cosas._, types._, klists._
 import ohnosequences.statika._
-import ohnosequences.fastarious._, fasta._, ncbiHeaders._
+import ohnosequences.fastarious.fasta._
 import ohnosequences.blast.api._
 import ohnosequences.awstools.s3._
 
@@ -26,7 +26,7 @@ trait AnyBlastDB {
   private[db] val sourceFasta: S3Object
   private[db] val sourceTable: S3Object
 
-  val predicate: Row => Boolean
+  val predicate: (Row, FASTA.Value) => Boolean
 }
 
 
@@ -100,7 +100,7 @@ class GenerateBlastDB[DB <: AnyBlastDB](val db: DB) extends Bundle(blastBundle) 
 
     processIterators(
       tableReader.iterator,
-      fasta.parseFastaDropErrors(fastaInFile.lines)
+      parseFastaDropErrors(fastaInFile.lines)
     )
 
     tableReader.close()
@@ -134,7 +134,7 @@ class GenerateBlastDB[DB <: AnyBlastDB](val db: DB) extends Bundle(blastBundle) 
           val fasta = nextFastas.next()
 
           // If the row satisfies the predicate, we write both it and the corresponding fasta
-          if (db.predicate(row)) {
+          if (db.predicate(row, fasta)) {
             // We want only ID to Taxa mapping
             tableWriter.writeRow(List(
               extID,

--- a/src/main/scala/blastDB.scala
+++ b/src/main/scala/blastDB.scala
@@ -1,4 +1,4 @@
-package era7bio.db.rna16s
+package era7bio.db
 
 import ohnosequences.cosas._, types._, klists._
 import ohnosequences.statika._
@@ -23,8 +23,8 @@ trait AnyBlastDB {
 
   lazy val name: String = getClass.getName
 
-  private[rna16s] val sourceFasta: S3Object
-  private[rna16s] val sourceTable: S3Object
+  private[db] val sourceFasta: S3Object
+  private[db] val sourceTable: S3Object
 
   val predicate: Row => Boolean
 }
@@ -35,7 +35,9 @@ case object blastBundle extends Blast("2.2.31")
 
 class GenerateBlastDB[DB <: AnyBlastDB](val db: DB) extends Bundle(blastBundle) {
 
-  val tableFormat = new TSVFormat {}
+  val tableFormat = new TSVFormat {
+    override val lineTerminator = "\n"
+  }
 
   // Files
   lazy val sources = file"sources"
@@ -44,8 +46,8 @@ class GenerateBlastDB[DB <: AnyBlastDB](val db: DB) extends Bundle(blastBundle) 
   lazy val sourceFasta: File = sources / "source.fasta"
   lazy val sourceTable: File = sources / "source.table.tsv"
 
-  lazy val outputFasta: File = outputs / "output.fasta"
-  lazy val outputTable: File = outputs / "id2taxa.tsv"
+  lazy val outputFasta: File = (outputs / "output.fasta").createIfNotExists()
+  lazy val outputTable: File = (outputs / "id2taxa.tsv").createIfNotExists()
 
 
   def instructions: AnyInstructions = {

--- a/src/main/scala/blastDB.scala
+++ b/src/main/scala/blastDB.scala
@@ -74,8 +74,8 @@ class GenerateBlastDB[DB <: AnyBlastDB](val db: DB) extends Bundle(blastBundle) 
   lazy val sourceFasta: File = sources / "source.fasta"
   lazy val sourceTable: File = sources / "source.table.tsv"
 
-  lazy val outputFasta: File = outputs / "output.fasta"
-  lazy val outputTable: File = outputs / "id2taxa.tsv"
+  lazy val outputFasta: File = outputs / s"${db.name}.fasta"
+  lazy val outputTable: File = outputs / db.release.id2taxa.name
 
 
   def instructions: AnyInstructions = {
@@ -127,7 +127,7 @@ class GenerateBlastDB[DB <: AnyBlastDB](val db: DB) extends Bundle(blastBundle) 
       val blastdbDir = (outputs / "blastdb").createDirectory()
       outputs.list
         .filter{ _.name.startsWith(s"${outputFasta.name}.") }
-        .foreach { _.moveTo(blastdbDir) }
+        .foreach { f => f.moveTo(blastdbDir / f.name) }
 
       // Uploading all together
       transferManager.uploadDirectory(

--- a/src/main/scala/blastDB.scala
+++ b/src/main/scala/blastDB.scala
@@ -23,10 +23,6 @@ trait AnyBlastDB {
 
   lazy val name: String = getClass.getName
 
-  // TODO sequence header stuff; this should be lcl()
-  // this is what will be added to the fasta headers
-  lazy val ncbiID = ncbiHeaders.name(name)
-
   private[rna16s] val sourceFasta: S3Object
   private[rna16s] val sourceTable: S3Object
 
@@ -125,8 +121,7 @@ class GenerateBlastDB[DB <: AnyBlastDB](val db: DB) extends Bundle(blastBundle) 
 
           fastasOutFile.append(
             fasta.update(
-              // TODO: build NCBI header stuff with lcl
-              header := FastaHeader(s"${fasta.getV(header).id}|${toHeader(db.ncbiID)}")
+              header := FastaHeader(s"${fasta.getV(header).id}|lcl|${db.name}")
             ).asString
           )
         }

--- a/src/main/scala/blastDB.scala
+++ b/src/main/scala/blastDB.scala
@@ -35,6 +35,8 @@ case object blastBundle extends Blast("2.2.31")
 
 class GenerateBlastDB[DB <: AnyBlastDB](val db: DB) extends Bundle(blastBundle) {
 
+  val tableFormat = new TSVFormat {}
+
   // Files
   lazy val sources = file"sources"
   lazy val outputs = file"outputs"
@@ -60,9 +62,8 @@ class GenerateBlastDB[DB <: AnyBlastDB](val db: DB) extends Bundle(blastBundle) 
       transferManager.download(db.sourceTable.bucket, db.sourceTable.key, sourceTable.toJava).waitForCompletion
     } -&-
     LazyTry {
-      // FIXME: what is the line separator here?
-      val tableReader = CSVReader.open(sourceTable.toJava)(new DefaultCSVFormat {})
-      val tableWriter = CSVWriter.open(outputTable.toJava, append = true)(new DefaultCSVFormat {})
+      val tableReader = CSVReader.open(sourceTable.toJava)(tableFormat)
+      val tableWriter = CSVWriter.open(outputTable.toJava, append = true)(tableFormat)
 
       processSources(
         tableWriter,

--- a/src/main/scala/blastDB.scala
+++ b/src/main/scala/blastDB.scala
@@ -1,10 +1,22 @@
 package era7bio.db.rna16s
 
-// import ohnosequences.cosas._, types._, klists._
-// import ohnosequences.statika._
+import ohnosequences.cosas._, types._, klists._
+import ohnosequences.statika._
 import ohnosequences.fastarious._, fasta._, ncbiHeaders._
 import ohnosequences.blast.api._
 import ohnosequences.awstools.s3._
+
+import ohnosequencesBundles.statika.Blast
+
+import com.amazonaws.auth._
+import com.amazonaws.services.s3.transfer._
+
+import com.github.tototoshi.csv._
+
+import better.files._
+
+import rnaCentralTable._
+
 
 trait AnyBlastDB {
   val dbType: BlastDBType
@@ -17,4 +29,107 @@ trait AnyBlastDB {
 
   private[rna16s] val sourceFasta: S3Object
   private[rna16s] val sourceTable: S3Object
+
+  val predicate: Row => Boolean
+}
+
+
+case object blastBundle extends Blast("2.2.31")
+
+
+class GenerateBlastDB[DB <: AnyBlastDB](val db: DB) extends Bundle(blastBundle) {
+
+  // Files
+  lazy val sources = file"sources"
+  lazy val outputs = file"outputs"
+
+  lazy val sourceFasta: File = sources / "source.fasta"
+  lazy val sourceTable: File = sources / "source.table.tsv"
+
+  lazy val outputFasta: File = outputs / "output.fasta"
+  lazy val outputTable: File = outputs / "id2taxa.tsv"
+
+
+  def instructions: AnyInstructions = {
+
+    val transferManager = new TransferManager(new InstanceProfileCredentialsProvider())
+
+    LazyTry {
+      println(s"""Downloading the sources...
+        |fasta: ${db.sourceFasta}
+        |table: ${db.sourceTable}
+        |""".stripMargin)
+
+      transferManager.download(db.sourceFasta.bucket, db.sourceFasta.key, sourceFasta.toJava).waitForCompletion
+      transferManager.download(db.sourceTable.bucket, db.sourceTable.key, sourceTable.toJava).waitForCompletion
+    } -&-
+    LazyTry {
+      // FIXME: what is the line separator here?
+      val tableReader = CSVReader.open(sourceTable.toJava)(new DefaultCSVFormat {})
+      val tableWriter = CSVWriter.open(outputTable.toJava, append = true)(new DefaultCSVFormat {})
+
+      processSources(
+        tableWriter,
+        outputFasta
+      )(tableReader.iterator,
+        fasta.parseFastaDropErrors(sourceFasta.lines)
+      )
+
+      tableReader.close()
+      tableWriter.close()
+    } -&-
+    seqToInstructions(
+      makeblastdb(
+        argumentValues =
+          in(outputFasta) ::
+          input_type(DBInputType.fasta) ::
+          dbtype(db.dbType) ::
+          *[AnyDenotation],
+        optionValues =
+          title(db.name) ::
+          *[AnyDenotation]
+      ).toSeq
+    )
+  }
+
+  @scala.annotation.tailrec
+  final def processSources(
+    tableWriter: CSVWriter,
+    fastasOutFile: File
+  )(rows: Iterator[Row],
+    fastas: Iterator[FASTA.Value]
+  ): (Iterator[Row], Iterator[FASTA.Value]) = {
+
+    if (!rows.hasNext || !fastas.hasNext) (Iterator(), Iterator())
+    else {
+      val row: Row = rows.next()
+      val id = row(HashID)
+
+      // Dropping all next rows with the same HashID
+      val nextRows = rows.dropWhile{ r => r(HashID) == id }
+      // Dropping until we ecnounter a sequence with this HashID
+      val nextFastas = fastas.dropWhile{ f => f.getV(header).id != id }
+
+      if(!nextFastas.hasNext) (Iterator(), Iterator())
+      else {
+        // This is the fasta corresponding to `row`
+        val fasta = nextFastas.next()
+
+        // If the row coplies to the predicate, we write it
+        if (db.predicate(row)) {
+          tableWriter.writeRow(row)
+          fastasOutFile.append(
+            fasta.update(
+              // TODO: build NCBI header stuff with lcl
+              header := FastaHeader(s"${fasta.getV(header).id}|${toHeader(db.ncbiID)}")
+            ).asString
+          )
+        }
+
+        // And anyway continue the cycle
+        processSources(tableWriter, fastasOutFile)(nextRows, nextFastas)
+      }
+    }
+  }
+
 }

--- a/src/main/scala/blastDB.scala
+++ b/src/main/scala/blastDB.scala
@@ -118,6 +118,7 @@ class GenerateBlastDB[DB <: AnyBlastDB](val db: DB) extends Bundle(blastBundle) 
       else {
         val row: Row = rows.next()
         val id = row(HashID)
+        val extID = s"${id}|lcl|${db.name}"
 
         // Dropping all next rows with the same HashID
         val nextRows = rows.dropWhile{ r => r(HashID) == id }
@@ -136,13 +137,13 @@ class GenerateBlastDB[DB <: AnyBlastDB](val db: DB) extends Bundle(blastBundle) 
           if (db.predicate(row)) {
             // We want only ID to Taxa mapping
             tableWriter.writeRow(List(
-              row(HashID),
+              extID,
               row(TaxID)
             ))
 
             fastaOutFile.appendLine(
               fasta.update(
-                header := FastaHeader(s"${fasta.getV(header).id}|lcl|${db.name}")
+                header := FastaHeader(extID)
               ).asString
             )
           }

--- a/src/main/scala/blastDB.scala
+++ b/src/main/scala/blastDB.scala
@@ -115,9 +115,14 @@ class GenerateBlastDB[DB <: AnyBlastDB](val db: DB) extends Bundle(blastBundle) 
         // This is the fasta corresponding to `row`
         val fasta = nextFastas.next()
 
-        // If the row coplies to the predicate, we write it
+        // If the row satisfies the predicate, we write both it and the corresponding fasta
         if (db.predicate(row)) {
-          tableWriter.writeRow(row)
+          // We want only ID to Taxa mapping
+          tableWriter.writeRow(List(
+            row(HashID),
+            row(TaxID)
+          ))
+
           fastasOutFile.append(
             fasta.update(
               // TODO: build NCBI header stuff with lcl

--- a/src/main/scala/blastDB.scala
+++ b/src/main/scala/blastDB.scala
@@ -1,0 +1,20 @@
+package era7bio.db.rna16s
+
+// import ohnosequences.cosas._, types._, klists._
+// import ohnosequences.statika._
+import ohnosequences.fastarious._, fasta._, ncbiHeaders._
+import ohnosequences.blast.api._
+import ohnosequences.awstools.s3._
+
+trait AnyBlastDB {
+  val dbType: BlastDBType
+
+  lazy val name: String = getClass.getName
+
+  // TODO sequence header stuff; this should be lcl()
+  // this is what will be added to the fasta headers
+  lazy val ncbiID = ncbiHeaders.name(name)
+
+  private[rna16s] val sourceFasta: S3Object
+  private[rna16s] val sourceTable: S3Object
+}

--- a/src/main/scala/rna16s.scala
+++ b/src/main/scala/rna16s.scala
@@ -11,6 +11,7 @@ import rnaCentralTable._
 
 
 case object rna16sDB extends AnyBlastDB {
+  
   val name = "era7bio.db.rna16s.fasta"
 
   val dbType = BlastDBType.nucl

--- a/src/main/scala/rna16s.scala
+++ b/src/main/scala/rna16s.scala
@@ -44,6 +44,7 @@ case object rna16sDB extends AnyBlastDB {
   private[db] val sourceFasta: S3Object = s3folder / s"rnacentral.${ver}.fasta"
   private[db] val sourceTable: S3Object = s3folder / s"id2taxa.active.${ver}.tsv"
 
+  val s3location: S3Folder = S3Folder("resources.ohnosequences.com", "db/rna16S/")
 
   /* Here we want to keep sequences which */
   val predicate: (Row, FASTA.Value) => Boolean = { (row, fasta) =>

--- a/src/main/scala/rna16s.scala
+++ b/src/main/scala/rna16s.scala
@@ -10,6 +10,7 @@ import rnaCentralTable._
 
 
 case object rna16sDB extends AnyBlastDB {
+  val name = "era7bio.db.rna16s"
 
   val dbType = BlastDBType.nucl
   /* The name identifying an RNA corresponding to 16S */
@@ -49,7 +50,9 @@ case object rna16sDB extends AnyBlastDB {
     2. their taxonomy association is *not* one of those in `uninformativeTaxIDs`
   */
   val predicate: Row => Boolean = { row =>
-    (row(GeneName) == geneNameFor16S) && !(uninformativeTaxIDs contains row(TaxID))
+     (row(GeneName) == geneNameFor16S) &&
+    !(uninformativeTaxIDs contains row(TaxID))
+    // filter by length > 1000
   }
 }
 

--- a/src/main/scala/rna16s.scala
+++ b/src/main/scala/rna16s.scala
@@ -11,7 +11,7 @@ import rnaCentralTable._
 
 
 case object rna16sDB extends AnyBlastDB {
-  val name = "era7bio.db.rna16s"
+  val name = "era7bio.db.rna16s.fasta"
 
   val dbType = BlastDBType.nucl
   /* The name identifying an RNA corresponding to 16S */

--- a/src/main/scala/rna16s.scala
+++ b/src/main/scala/rna16s.scala
@@ -1,123 +1,22 @@
 package era7bio.db.rna16s
 
-import ohnosequences.cosas._, types._, klists._
-import ohnosequences.statika._
-import ohnosequences.fastarious._, fasta._, ncbiHeaders._
 import ohnosequences.blast.api._
 import ohnosequences.awstools.s3._
 
-import ohnosequencesBundles.statika.Blast
-
-import com.amazonaws.auth._
-import com.amazonaws.services.s3.transfer._
-
-import com.github.tototoshi.csv._
-
-import better.files._
-
 import rnaCentralTable._
 
-case object blastBundle extends Blast("2.2.31")
 
-// TODO this should get the input fasta from somewhere, download it and run makeblastdb etc
-// blast should be a dependency
-abstract class GenerateBlastDB[DB <: AnyBlastDB](val db: DB) extends Bundle(blastBundle) {
+case object rna16sDB extends AnyBlastDB {
+  val dbType = BlastDBType.nucl
 
-  val predicate: Row => Boolean
+  private val ver = "5.0"
+  private val s3folder = S3Folder("resources.ohnosequences.com", s"rnacentral/${ver}")
 
-  // Files
-  lazy val sources = file"sources"
-  lazy val outputs = file"outputs"
+  private[rna16s] val sourceFasta: S3Object = s3folder / s"rnacentral.${ver}.fasta"
+  private[rna16s] val sourceTable: S3Object = s3folder / s"id2taxa.active.${ver}.tsv"
 
-  lazy val sourceFasta: File = sources / "source.fasta"
-  lazy val sourceTable: File = sources / "source.table.tsv"
-
-  lazy val outputFasta: File = outputs / "output.fasta"
-  lazy val outputTable: File = outputs / "id2taxa.tsv"
-
-
-  def instructions: AnyInstructions = {
-
-    val transferManager = new TransferManager(new InstanceProfileCredentialsProvider())
-
-    LazyTry {
-      println(s"""Downloading the sources...
-        |fasta: ${db.sourceFasta}
-        |table: ${db.sourceTable}
-        |""".stripMargin)
-
-      transferManager.download(db.sourceFasta.bucket, db.sourceFasta.key, sourceFasta.toJava)
-      transferManager.download(db.sourceTable.bucket, db.sourceTable.key, sourceTable.toJava)
-    } -&-
-    LazyTry {
-      // FIXME: what is the line separator here?
-      val tableReader = CSVReader.open(sourceTable.toJava)(new DefaultCSVFormat {})
-      val tableWriter = CSVWriter.open(outputTable.toJava, append = true)(new DefaultCSVFormat {})
-
-      processSources(
-        tableWriter,
-        outputFasta
-      )(tableReader.iterator,
-        fasta.parseFastaDropErrors(sourceFasta.lines)
-      )
-
-      tableReader.close()
-      tableWriter.close()
-    } -&-
-    seqToInstructions(
-      makeDB(outputFasta).toSeq
-    )
+  val predicate: Row => Boolean = { row =>
+    row(GeneName) == "16s"
+    // TODO: what else?
   }
-
-  // TODO build NCBI header stuff with lcl
-  @scala.annotation.tailrec
-  final def processSources(
-    tableWriter: CSVWriter,
-    fastasOutFile: File
-  )(rows: Iterator[Row],
-    fastas: Iterator[FASTA.Value]
-  ): (Iterator[Row], Iterator[FASTA.Value]) = {
-
-    if (!rows.hasNext || !fastas.hasNext) (Iterator(), Iterator())
-    else {
-      val row: Row = rows.next()
-      val id = row(HashID)
-
-      // Dropping all next rows with the same HashID
-      val nextRows = rows.dropWhile{ r => r(HashID) == id }
-      // Dropping until we ecnounter a sequence with this HashID
-      val nextFastas = fastas.dropWhile{ f => f.getV(header).id != id }
-
-      if(!nextFastas.hasNext) (Iterator(), Iterator())
-      else {
-        // This is the fasta corresponding to `row`
-        val fasta = nextFastas.next()
-
-        // If the row coplies to the predicate, we write it
-        if (predicate(row)) {
-          tableWriter.writeRow(row)
-          fastasOutFile.append(
-            fasta.update(
-              header := FastaHeader(s"${fasta.getV(header).id}|${toHeader(db.ncbiID)}")
-            ).asString
-          )
-        }
-
-        // And anyway continue the cycle
-        processSources(tableWriter, fastasOutFile)(nextRows, nextFastas)
-      }
-    }
-  }
-
-  def makeDB(inputFasta: File) =
-    makeblastdb(
-      argumentValues =
-        in(inputFasta)                ::
-        input_type(DBInputType.fasta) ::
-        dbtype(db.dbType)             ::
-        *[AnyDenotation],
-      optionValues =
-        title(db.name) ::
-        *[AnyDenotation]
-    )
 }

--- a/src/main/scala/rna16s.scala
+++ b/src/main/scala/rna16s.scala
@@ -1,7 +1,10 @@
-package era7bio.db.rna16s
+package era7bio.db
 
 import ohnosequences.blast.api._
-import ohnosequences.awstools.s3._
+import ohnosequences.awstools._, ec2._, InstanceType._, s3._, regions._
+import ohnosequences.statika._, aws._
+
+import era7.defaults._, loquats._
 
 import rnaCentralTable._
 
@@ -12,11 +15,43 @@ case object rna16sDB extends AnyBlastDB {
   private val ver = "5.0"
   private val s3folder = S3Folder("resources.ohnosequences.com", s"rnacentral/${ver}")
 
-  private[rna16s] val sourceFasta: S3Object = s3folder / s"rnacentral.${ver}.fasta"
-  private[rna16s] val sourceTable: S3Object = s3folder / s"id2taxa.active.${ver}.tsv"
+  private[db] val sourceFasta: S3Object = s3folder / s"rnacentral.${ver}.fasta"
+  private[db] val sourceTable: S3Object = s3folder / s"id2taxa.active.${ver}.tsv"
 
   val predicate: Row => Boolean = { row =>
-    row(GeneName) == "16s"
+    row(GeneName) == "16S rRNA"
     // TODO: what else?
   }
+}
+
+case object rna16sDBRelease {
+
+  case object generateRna16sDB extends GenerateBlastDB(rna16sDB)
+
+  case object compat extends Compatible(
+    amznAMIEnv(
+      AmazonLinuxAMI(Region.Ireland, HVM, InstanceStore),
+      javaHeap = 20 // in G
+    ),
+    generateRna16sDB,
+    generated.metadata.DbRna16s
+  )
+
+  def launch(user: AWSUser): List[String] = {
+    EC2.create(user.profile)
+      .runInstances(
+        amount = 1,
+        compat.instanceSpecs(
+          c3.x2large,
+          user.keypair.name,
+          Some(ec2Roles.projects.name)
+        )
+      ).map { inst =>
+
+        val id = inst.getInstanceId
+        println(s"Launched [${id}]")
+        id
+      }
+  }
+
 }

--- a/src/main/scala/rna16s.scala
+++ b/src/main/scala/rna16s.scala
@@ -4,36 +4,109 @@ import ohnosequences.cosas._, types._, klists._
 import ohnosequences.statika._
 import ohnosequences.fastarious._, fasta._, ncbiHeaders._
 import ohnosequences.blast.api._
+import ohnosequences.awstools.s3._
+
+import ohnosequencesBundles.statika.Blast
+
+import com.amazonaws.auth._
+import com.amazonaws.services.s3.transfer._
+
+import com.github.tototoshi.csv._
+
 import better.files._
 
-trait AnyBlastDB {
+import rnaCentralTable._
 
-  lazy val name: String = getClass.getName
-  // TODO sequence header stuff; this should be lcl()
-  // this is what will be added to the fasta headers
-  lazy val ncbiID = ncbiHeaders.name(name)
-
-  // TODO S3 Object address; AnyData?
-  val sourceFasta: String
-  val dbType: BlastDBType
-}
+case object blastBundle extends Blast("2.2.31")
 
 // TODO this should get the input fasta from somewhere, download it and run makeblastdb etc
 // blast should be a dependency
-trait GenerateBlastDB[DB <: AnyBlastDB] extends Bundle() {
+abstract class GenerateBlastDB[DB <: AnyBlastDB](val db: DB) extends Bundle(blastBundle) {
 
-  val db: DB
+  val predicate: Row => Boolean
+
+  // Files
+  lazy val sources = file"sources"
+  lazy val outputs = file"outputs"
+
+  lazy val sourceFasta: File = sources / "source.fasta"
+  lazy val sourceTable: File = sources / "source.table.tsv"
+
+  lazy val outputFasta: File = outputs / "output.fasta"
+  lazy val outputTable: File = outputs / "id2taxa.tsv"
+
+
+  def instructions: AnyInstructions = {
+
+    val transferManager = new TransferManager(new InstanceProfileCredentialsProvider())
+
+    LazyTry {
+      println(s"""Downloading the sources...
+        |fasta: ${db.sourceFasta}
+        |table: ${db.sourceTable}
+        |""".stripMargin)
+
+      transferManager.download(db.sourceFasta.bucket, db.sourceFasta.key, sourceFasta.toJava)
+      transferManager.download(db.sourceTable.bucket, db.sourceTable.key, sourceTable.toJava)
+    } -&-
+    LazyTry {
+      // FIXME: what is the line separator here?
+      val tableReader = CSVReader.open(sourceTable.toJava)(new DefaultCSVFormat {})
+      val tableWriter = CSVWriter.open(outputTable.toJava, append = true)(new DefaultCSVFormat {})
+
+      processSources(
+        tableWriter,
+        outputFasta
+      )(tableReader.iterator,
+        fasta.parseFastaDropErrors(sourceFasta.lines)
+      )
+
+      tableReader.close()
+      tableWriter.close()
+    } -&-
+    seqToInstructions(
+      makeDB(outputFasta).toSeq
+    )
+  }
 
   // TODO build NCBI header stuff with lcl
-  def processInput(inputFasta: File, drop: FASTA.Value => Boolean, outputFasta: File): File = {
+  @scala.annotation.tailrec
+  final def processSources(
+    tableWriter: CSVWriter,
+    fastasOutFile: File
+  )(rows: Iterator[Row],
+    fastas: Iterator[FASTA.Value]
+  ): (Iterator[Row], Iterator[FASTA.Value]) = {
 
-    fasta
-      .parseFastaDropErrors(inputFasta.lines)
-      .filterNot(drop)
-      .map(fa => fa.update(header := FastaHeader(s"${fa.getV(header).id}|${toHeader(db.ncbiID)}")))
-      .appendTo(outputFasta)
+    if (!rows.hasNext || !fastas.hasNext) (Iterator(), Iterator())
+    else {
+      val row: Row = rows.next()
+      val id = row(HashID)
 
-    outputFasta
+      // Dropping all next rows with the same HashID
+      val nextRows = rows.dropWhile{ r => r(HashID) == id }
+      // Dropping until we ecnounter a sequence with this HashID
+      val nextFastas = fastas.dropWhile{ f => f.getV(header).id != id }
+
+      if(!nextFastas.hasNext) (Iterator(), Iterator())
+      else {
+        // This is the fasta corresponding to `row`
+        val fasta = nextFastas.next()
+
+        // If the row coplies to the predicate, we write it
+        if (predicate(row)) {
+          tableWriter.writeRow(row)
+          fastasOutFile.append(
+            fasta.update(
+              header := FastaHeader(s"${fasta.getV(header).id}|${toHeader(db.ncbiID)}")
+            ).asString
+          )
+        }
+
+        // And anyway continue the cycle
+        processSources(tableWriter, fastasOutFile)(nextRows, nextFastas)
+      }
+    }
   }
 
   def makeDB(inputFasta: File) =
@@ -44,6 +117,7 @@ trait GenerateBlastDB[DB <: AnyBlastDB] extends Bundle() {
         dbtype(db.dbType)             ::
         *[AnyDenotation],
       optionValues =
-        makeblastdb.defaults.update( title(db.name) ).value
+        title(db.name) ::
+        *[AnyDenotation]
     )
 }

--- a/src/main/scala/rna16s.scala
+++ b/src/main/scala/rna16s.scala
@@ -7,7 +7,31 @@ import rnaCentralTable._
 
 
 case object rna16sDB extends AnyBlastDB {
+
   val dbType = BlastDBType.nucl
+  /* The name identifying an RNA corresponding to 16S */
+  val geneNameFor16S = "16S rRNA"
+  /* These are NCBI taxonomy IDs corresponding to taxa which is at best uniformative. The `String` value is the name of the corresponding taxon, for documentation purposes. */
+  val uninformativeTaxIDsMap = Map(
+    32644   -> "unclassified",
+    358574  -> "uncultured microorganism",
+    155900  -> "uncultured organism",
+    415540  -> "uncultured marine microorganism",
+    198431  -> "uncultured prokaryote",
+    77133   -> "uncultured bacterium",
+    115547  -> "uncultured archaeon",
+    56763   -> "uncultured marine archaeon",
+    152507  -> "uncultured actinobacterium",
+    1211    -> "uncultured cyanobacterium",
+    153809  -> "uncultured proteobacterium",
+    86027   -> "uncultured beta proteobacterium",
+    86473   -> "uncultured gamma proteobacterium",
+    34034   -> "uncultured delta proteobacterium",
+    56765   -> "uncultured marine bacterium",
+    115414  -> "uncultured marine alpha proteobacterium"
+  )
+
+  val uninformativeTaxIDs = uninformativeTaxIDsMap.keys.map(_.toString).toSet
 
   private val ver = "5.0"
   private val s3folder = S3Folder("resources.ohnosequences.com", s"rnacentral/${ver}")
@@ -15,8 +39,13 @@ case object rna16sDB extends AnyBlastDB {
   private[rna16s] val sourceFasta: S3Object = s3folder / s"rnacentral.${ver}.fasta"
   private[rna16s] val sourceTable: S3Object = s3folder / s"id2taxa.active.${ver}.tsv"
 
+  /*
+    Here we want to keep sequences which
+
+    1. are annotated as encoding 16S
+    2. their taxonomy association is *not* one of those in `uninformativeTaxIDs`
+  */
   val predicate: Row => Boolean = { row =>
-    row(GeneName) == "16s"
-    // TODO: what else?
+    (row(GeneName) == geneNameFor16S) && !(uninformativeTaxIDs contains row(TaxID))
   }
 }

--- a/src/main/scala/rnaCentral.scala
+++ b/src/main/scala/rnaCentral.scala
@@ -1,4 +1,4 @@
-package era7bio.db.rna16s
+package era7bio.db
 
 import ohnosequences.cosas._, types._, klists._
 import ohnosequences.statika._

--- a/src/main/scala/rnaCentral.scala
+++ b/src/main/scala/rnaCentral.scala
@@ -13,6 +13,8 @@ import com.amazonaws.services.s3.transfer._
 
 import com.github.tototoshi.csv._
 
+// TODO: move all this code to the era7bio/rnacentral repo (and use cosas/records)
+
 case object rnaCentralTable {
 
   // TODO: use a better representation for the table row

--- a/src/main/scala/rnaCentral.scala
+++ b/src/main/scala/rnaCentral.scala
@@ -1,0 +1,50 @@
+package era7bio.db.rna16s
+
+import ohnosequences.cosas._, types._, klists._
+import ohnosequences.statika._
+import ohnosequences.fastarious._, fasta._, ncbiHeaders._
+import ohnosequences.blast.api._
+import ohnosequences.awstools.s3._
+
+import ohnosequencesBundles.statika.Blast
+
+import com.amazonaws.auth._
+import com.amazonaws.services.s3.transfer._
+
+import com.github.tototoshi.csv._
+
+case object rnaCentralTable {
+
+  // TODO: use a better representation for the table row
+  type Row = Seq[String]
+
+  sealed trait Field
+
+  case object HashID   extends Field
+  case object SourceDB extends Field
+  case object SourceID extends Field
+  case object TaxID    extends Field
+  case object RNAType  extends Field
+  case object GeneName extends Field
+
+  // Defines the order of the columns
+  final val fields = Seq[Field](
+    HashID,
+    SourceDB,
+    SourceID,
+    TaxID,
+    RNAType,
+    GeneName
+  )
+
+  implicit def rowOps(row: Row): RowOps = RowOps(row)
+
+}
+
+case class RowOps(row: rnaCentralTable.Row) extends AnyVal {
+  import rnaCentralTable._
+
+  def toMap: Map[Field, String] = fields.zip(row).toMap
+
+  def apply(field: Field): String = this.toMap.apply(field)
+}

--- a/src/test/scala/Dbrna16s.scala
+++ b/src/test/scala/Dbrna16s.scala
@@ -1,16 +1,19 @@
-package era7bio.dbrna16s.test
+package era7bio.db.test
 
+import era7bio.db.rna16sDBRelease._
 import org.scalatest.FunSuite
+import better.files._
 
-import era7bio.dbrna16s._
 
 class Dbrna16sTest extends FunSuite {
 
-  test("Dummy test coming from the template") {
+  test("Process some sample files") {
 
-    assert(
-
-      12 === 12
+    generateRna16sDB.processSources(
+      file"source.table.sample.tsv",
+      file"output.table.sample.tsv".clear()
+    )(file"source.sample.fasta",
+      file"output.sample.fasta".clear()
     )
   }
 }


### PR DESCRIPTION
We need a concept of blast database, which includes its name (it will be passed as arg to `-title` in `makeblastdb`). Given that, we can easily add a reference to the db through

```
>${id}|lcl|${db}
ATTTCGGTACATCATTTCACATTGTAC
```

This way BLAST results will yield something like `00015CA37|lcl|era7bio.db.rna16S` as the value of `sseqid`.
