### PR TITLE
Change the artifact name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 Nice.scalaProject
 
-name          := "db.rna16s"
+name          := "db-rna16s"
 organization  := "era7bio"
-description   := "db.rna16s project"
+description   := "db-rna16s project"
 
 resolvers := Seq(
   "Era7 private maven releases"  at s3("private.releases.era7.com").toHttps(s3region.value.toString),


### PR DESCRIPTION
Better not to use dots in project names, because it's confusing: project name is with _dots_, but the published artifact ID is with _dashes_.
