### PR TITLE
Taxonomy-aware filtering

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,18 @@ libraryDependencies ++= Seq(
   "ohnosequences" %% "blast-api"       % "0.7.0",
   "ohnosequences" %% "statika"         % "2.0.0-M5",
   "era7bio"       %% "rnacentraldb"    % "0.2.1",
+  "ohnosequences-bundles" %% "bio4j-dist" % "0.2.0",
+  // Test:
   "era7"          %% "defaults"  % "0.1.0" % Test,
   "org.scalatest" %% "scalatest" % "2.2.6" % Test
+)
+
+
+dependencyOverrides ++= Set(
+  "commons-logging"            % "commons-logging"     % "1.1.3",
+  "commons-codec"              % "commons-codec"       % "1.7",
+  "org.apache.httpcomponents"  % "httpclient"          % "4.5.1",
+  "org.slf4j"                  % "slf4j-api"           % "1.7.7"
 )
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -29,14 +29,20 @@ libraryDependencies ++= Seq(
 
 
 dependencyOverrides ++= Set(
-  "commons-logging"            % "commons-logging"     % "1.1.3",
-  "commons-codec"              % "commons-codec"       % "1.7",
   "org.apache.httpcomponents"  % "httpclient"          % "4.5.1",
   "org.slf4j"                  % "slf4j-api"           % "1.7.7"
 )
 
 
 fatArtifactSettings
+
+// copied from bio4j-titan:
+mergeStrategy in assembly ~= { old => {
+    case "log4j.properties"                       => MergeStrategy.filterDistinctLines
+    case PathList("org", "apache", "commons", _*) => MergeStrategy.first
+    case x                                        => old(x)
+  }
+}
 
 enablePlugins(BuildInfoPlugin)
 buildInfoPackage := "generated.metadata"

--- a/docs/src/main/scala/rna16s.scala.md
+++ b/docs/src/main/scala/rna16s.scala.md
@@ -10,7 +10,65 @@ import ohnosequences.statika._, aws._
 import era7bio.db.RNACentral5._
 import era7bio.db.csvUtils._
 
+import ohnosequencesBundles.statika._
 
+import com.thinkaurelius.titan.core._, schema._
+import com.bio4j.model.ncbiTaxonomy.NCBITaxonomyGraph._
+import com.bio4j.titan.model.ncbiTaxonomy._
+import com.bio4j.titan.util.DefaultTitanGraph
+
+
+case object bio4jTaxonomyBundle extends AnyBio4jDist {
+
+  lazy val s3folder: S3Folder = S3Folder("resources.ohnosequences.com", "16s/bio4j-taxonomy/")
+
+  lazy val configuration = DefaultBio4jTitanConfig(dbLocation)
+
+  // the graph; its only (direct) use is for indexes
+  // FIXME: this works but still with errors, should be fixed (something about transactions)
+  lazy val graph: TitanNCBITaxonomyGraph =
+    new TitanNCBITaxonomyGraph(
+      new DefaultTitanGraph(TitanFactory.open(configuration))
+    )
+
+
+  type TaxonNode = com.bio4j.model.ncbiTaxonomy.vertices.NCBITaxon[
+    DefaultTitanGraph,
+    TitanVertex, VertexLabelMaker,
+    TitanEdge, EdgeLabelMaker
+  ]
+
+  implicit class IdOps(val id: String) extends AnyVal {
+
+    def isDescendantOfOneIn(ancestors: Set[String]): Boolean = {
+      // Java to Scala
+      def optional[T](jopt: java.util.Optional[T]): Option[T] =
+        if (jopt.isPresent) Some(jopt.get) else None
+
+      @ annotation.tailrec
+      def isDescendantOfOneIn_rec(node: TaxonNode): Boolean =
+        optional(node.ncbiTaxonParent_inV) match {
+          case None => false
+          case Some(parent) =>
+            if (ancestors.contains( parent.id() )) true
+            else isDescendantOfOneIn_rec(parent)
+        }
+
+      optional(graph.nCBITaxonIdIndex.getVertex(id))
+        .map(isDescendantOfOneIn_rec)
+        .getOrElse(false)
+    }
+  }
+}
+```
+
+
+## 16S RNA BLAST database
+
+This contains the specification of our 16S BLAST database. All sequences are obtained from RNACentral, with sequences satisfying `predicate` being those included.
+
+
+```scala
 case object rna16s extends AnyBlastDB {
 
   val name = "era7bio.db.rna16s"
@@ -22,13 +80,19 @@ case object rna16s extends AnyBlastDB {
   val s3location: S3Folder = S3Folder("resources.ohnosequences.com", "db/rna16s/")
 ```
 
-The name identifying an RNA corresponding to 16S
+We are using the ribosomal RNA type annotation on RNACentral as a first catch-all filter. We are aware of the existence of a gene annotation corresponding to 16S, that we are **not using** due to a significant amount of 16S sequences lacking the corresponding annotation.
 
 ```scala
-  val geneNameFor16S = "16S rRNA"
+  val ribosomalRNAType = "rRNA"
 ```
 
-These are NCBI taxonomy IDs corresponding to taxa which is at best uniformative. The `String` value is the name of the corresponding taxon, for documentation purposes.
+The sequence length threshold for a sequence to be admitted as 16S.
+
+```scala
+  val minimum16SLength: Int = 1300
+```
+
+These are NCBI taxonomy IDs corresponding to taxa which are at best uniformative. The `String` value is the name of the corresponding taxon, for documentation purposes.
 
 ```scala
   val uninformativeTaxIDsMap = Map(
@@ -53,33 +117,51 @@ These are NCBI taxonomy IDs corresponding to taxa which is at best uniformative.
   val uninformativeTaxIDs: Set[String] = uninformativeTaxIDsMap.keys.map(_.toString).toSet
 ```
 
-Here we want to keep sequences which
+
+#### Database defining predicate
+
+Sequences that satisfy this predicate (on themselves together with their annotation) are included in this database.
+
 
 ```scala
+  import bio4jTaxonomyBundle._
   val predicate: (Row, FASTA.Value) => Boolean = { (row, fasta) =>
 ```
 
-- are annotated as encoding 16S
+- are annotated as rRNA
 
 ```scala
-     (row.select(gene_name) == geneNameFor16S) &&
+     row.select(rna_type).contains(ribosomalRNAType)        &&
 ```
 
 - their taxonomy association is *not* one of those in `uninformativeTaxIDs`
 
 ```scala
-    !(uninformativeTaxIDs contains row.select(tax_id)) &&
+    ( ! uninformativeTaxIDs.contains(row.select(tax_id)) )  &&
 ```
 
-- and the corresponding sequence is not shorter than 1000 BP
+- the corresponding sequence is not shorter than the threshold
 
 ```scala
-     (fasta.getV(sequence).value.length >= 1000)
+    (fasta.getV(sequence).value.length >= minimum16SLength) &&
+```
+
+- is a descendant of either Archaea or Bacteria
+
+```scala
+    row.select(tax_id).isDescendantOfOneIn(
+      Set(
+        "2157", // Archaea
+        "2"     // Bacteria
+      )
+    )
   }
 
-
   // bundle to generate the DB (see the runBundles file in tests)
-  case object generate extends GenerateBlastDB(this)
+  case object generate extends GenerateBlastDB(this) {
+
+    override val bundleDependencies: List[AnyBundle] = List(bio4jTaxonomyBundle)
+  }
 
   // bundle to obtain and use the generated release
   case object release extends BlastDBRelease(generate)
@@ -90,7 +172,7 @@ Here we want to keep sequences which
 
 
 
-[main/scala/rna16s.scala]: rna16s.scala.md
+[test/scala/runBundles.scala]: ../../test/scala/runBundles.scala.md
 [test/scala/compats.scala]: ../../test/scala/compats.scala.md
 [test/scala/Dbrna16s.scala]: ../../test/scala/Dbrna16s.scala.md
-[test/scala/runBundles.scala]: ../../test/scala/runBundles.scala.md
+[main/scala/rna16s.scala]: rna16s.scala.md

--- a/docs/src/test/scala/Dbrna16s.scala.md
+++ b/docs/src/test/scala/Dbrna16s.scala.md
@@ -25,7 +25,7 @@ class Dbrna16sTest extends FunSuite {
 
 
 
-[main/scala/rna16s.scala]: ../../main/scala/rna16s.scala.md
+[test/scala/runBundles.scala]: runBundles.scala.md
 [test/scala/compats.scala]: compats.scala.md
 [test/scala/Dbrna16s.scala]: Dbrna16s.scala.md
-[test/scala/runBundles.scala]: runBundles.scala.md
+[main/scala/rna16s.scala]: ../../main/scala/rna16s.scala.md

--- a/docs/src/test/scala/compats.scala.md
+++ b/docs/src/test/scala/compats.scala.md
@@ -22,7 +22,7 @@ case object rna16sCompats {
 
 
 
-[main/scala/rna16s.scala]: ../../main/scala/rna16s.scala.md
+[test/scala/runBundles.scala]: runBundles.scala.md
 [test/scala/compats.scala]: compats.scala.md
 [test/scala/Dbrna16s.scala]: Dbrna16s.scala.md
-[test/scala/runBundles.scala]: runBundles.scala.md
+[main/scala/rna16s.scala]: ../../main/scala/rna16s.scala.md

--- a/docs/src/test/scala/runBundles.scala.md
+++ b/docs/src/test/scala/runBundles.scala.md
@@ -31,7 +31,7 @@ case object rna16sDBRelease {
 
 
 
-[main/scala/rna16s.scala]: ../../main/scala/rna16s.scala.md
+[test/scala/runBundles.scala]: runBundles.scala.md
 [test/scala/compats.scala]: compats.scala.md
 [test/scala/Dbrna16s.scala]: Dbrna16s.scala.md
-[test/scala/runBundles.scala]: runBundles.scala.md
+[main/scala/rna16s.scala]: ../../main/scala/rna16s.scala.md

--- a/src/main/scala/rna16s.scala
+++ b/src/main/scala/rna16s.scala
@@ -99,11 +99,11 @@ case object rna16s extends AnyBlastDB {
       fasta.getV(header).description.toLowerCase.contains("small subunit ribosomal")
     ) &&
     /* - are annotated as rRNA */
-     row.select(rna_type).toLowerCase.contains("rrna") ||
+     row.select(rna_type).toLowerCase.contains("rrna") &&
     /* - their taxonomy association is *not* one of those in `uninformativeTaxIDs` */
     (uninformativeTaxIDs contains row.select(tax_id)) &&
     /* - and the corresponding sequence is not shorter than 1300 BP */
-    (fasta.getV(sequence).value.length >= 1300) ||
+    (fasta.getV(sequence).value.length >= 1300) &&
     /* - is a descendant of either Archaea or Bacteria */
     bio4jTaxonomyBundle.checkAncestors(
       row.select(tax_id), Set(

--- a/src/main/scala/rna16s.scala
+++ b/src/main/scala/rna16s.scala
@@ -127,7 +127,8 @@ case object rna16s extends AnyBlastDB {
   // bundle to generate the DB (see the runBundles file in tests)
   case object generate extends GenerateBlastDB(this) {
 
-    override val bundleDependencies: List[AnyBundle] = List(bio4jTaxonomyBundle)
+    override val bundleDependencies: List[AnyBundle] =
+      List[AnyBundle](bio4jTaxonomyBundle, blastBundle)
   }
 
   // bundle to obtain and use the generated release

--- a/src/main/scala/rna16s.scala
+++ b/src/main/scala/rna16s.scala
@@ -102,8 +102,8 @@ case object rna16s extends AnyBlastDB {
      row.select(rna_type).toLowerCase.contains("rrna") ||
     /* - their taxonomy association is *not* one of those in `uninformativeTaxIDs` */
     (uninformativeTaxIDs contains row.select(tax_id)) &&
-    /* - and the corresponding sequence is not shorter than 1000 BP */
-    (fasta.getV(sequence).value.length >= 1000) ||
+    /* - and the corresponding sequence is not shorter than 1300 BP */
+    (fasta.getV(sequence).value.length >= 1300) ||
     /* - is a descendant of either Archaea or Bacteria */
     bio4jTaxonomyBundle.checkAncestors(
       row.select(tax_id), Set(

--- a/src/main/scala/rna16s.scala
+++ b/src/main/scala/rna16s.scala
@@ -71,6 +71,8 @@ case object rna16s extends AnyBlastDB {
       fasta.getV(header).description.toLowerCase.contains("16s") ||
       fasta.getV(header).description.toLowerCase.contains("small subunit ribosomal")
      ) &&
+     /* - are annotated as rRNA */
+      row.select(rna_type).toLowerCase.contains("rrna") ||
      /* - their taxonomy association is *not* one of those in `uninformativeTaxIDs` */
     !(uninformativeTaxIDs contains row.select(tax_id)) &&
      /* - and the corresponding sequence is not shorter than 1000 BP */

--- a/src/main/scala/rna16s.scala
+++ b/src/main/scala/rna16s.scala
@@ -8,6 +8,27 @@ import ohnosequences.statika._, aws._
 import era7bio.db.RNACentral5._
 import era7bio.db.csvUtils._
 
+import ohnosequencesBundles.statika._
+
+import com.thinkaurelius.titan.core._
+import com.bio4j.titan.model.ncbiTaxonomy._
+import com.bio4j.titan.util.DefaultTitanGraph
+import org.apache.commons.configuration.Configuration
+
+
+case object bio4jTaxonomyBundle extends AnyBio4jDist {
+
+  lazy val s3folder: S3Folder = S3Folder("resources.ohnosequences.com", "16s/bio4j-taxonomy/")
+
+  lazy val configuration: Configuration = DefaultBio4jTitanConfig(dbLocation)
+
+  // the graph; its only (direct) use is for indexes
+  // FIXME: this works but still with errors, should be fixed (something about transactions)
+  lazy val graph: TitanNCBITaxonomyGraph =
+    new TitanNCBITaxonomyGraph(
+      new DefaultTitanGraph(TitanFactory.open(configuration))
+    )
+}
 
 case object rna16s extends AnyBlastDB {
 


### PR DESCRIPTION
A significant amount of 16S sequences are lost with the current filter. As an example, this RNACentral entry
- http://rnacentral.org/rna/URS00005C321D/243230

has as header in the FASTA file

```
>URS00005C321D Deinococcus radiodurans R1 rrn
```

The sequences we are going to keep are those which
1. have rRNA in the `rna_type` field
2. their taxonomy assignment is 
   1. not one of the blacklisted ids we had, _and_
   2. a descendant of either Bacteria (tax id 2) or Archaea (tax id 2157)
3. are longer than 1300
