### PR TITLE
Misassignments and sequences with exactly one assignment

### DIFF
--- a/docs/src/test/scala/dropInconsistentAssignments.scala.md
+++ b/docs/src/test/scala/dropInconsistentAssignments.scala.md
@@ -58,14 +58,7 @@ We take their LCA which is `subgenusABC` and look at its parent: `genusABC`. Eac
 This step actually consists in two separate steps:
 
 1. We run MG7 with input the output from the drop redundant assignments step, and as reference database the same but the sequence we are using as query.
-2. For each sequence we check the relation of its assignments with the corresponding LCA that we've got from MG7. If some assignment is too far away from the LCA in the taxonomic tree, it is discarded.
-
-  Right now, if a sequence has only one (single) assignment, it is not tested with the described filter, because
-
-  + it may represent a rare organism that doesn't necessarily have relations with its taxonomic neighbors
-  + it can be an organism that was originally misclassified and put in the taxonomy far away from its real relatives (that could be discovered later, for example)
-
-  After this step BLAST database is generated again.
+2. For each sequence we check the relation of its assignments with the corresponding LCA that we've got from MG7. If some assignment is too far away from the LCA in the taxonomic tree, it is discarded. After this step the BLAST database is generated again.
 
 Almost all `99.8%` of the sequences from the drop redundant assignments step pass  this filter, because it's mostly about filtering out *wrong* assignments and there are not many sequences that get all assignments discarded.
 
@@ -111,19 +104,10 @@ Then we process the source table and compare assignments with LCA from MG7. We k
       case (row, fasta) => {
 
         val (id, taxas) = idTaxasFromRow(row)
-```
 
-If there's only one assignment we don't touch it
-
-```scala
-        // NOTE: see https://github.com/ohnosequences/db.rna16s/pull/32#discussion_r71972097 for the reasons
-        if (taxas.length == 1)
-          accept(id, taxas, fasta)
-        else {
-
-          id2mg7lca.get(id)
-            .flatMap(taxonomyGraph.getTaxon)
-            .flatMap(_.parent)
+        id2mg7lca.get(id)
+          .flatMap(taxonomyGraph.getTaxon)
+          .flatMap(_.parent)
 ```
 
 
@@ -134,20 +118,19 @@ Note that the previous filters guarantee that the mg7 LCA IDs *are* in the NCBI 
 
 
 ```scala
-            .fold( accept(id, taxas, fasta) ) {
-              lcaParent => {
+          .fold( accept(id, taxas, fasta) ) {
+            lcaParent => {
 ```
 
 Here we discard those taxa whose lineage does **not** contain the *parent* of the lca assignment.
 
 ```scala
-                val (acceptedTaxas, rejectedTaxas) =
-                  taxas.partition { taxa => (taxonomyGraph getTaxon taxa).fold(false)( lcaParent isInLineageOf _ ) }
+              val (acceptedTaxas, rejectedTaxas) =
+                taxas.partition { taxa => (taxonomyGraph getTaxon taxa).fold(false)( lcaParent isInLineageOf _ ) }
 
-                writeOutput(id, acceptedTaxas, rejectedTaxas, fasta)
-              }
+              writeOutput(id, acceptedTaxas, rejectedTaxas, fasta)
             }
-        }
+          }
       }
     }
   }


### PR DESCRIPTION
If a sequence has only one assignment, we are considering it valid, whatever the mg7 assignment is. Why? Is it on purpose?

After #37
