### PR TITLE
Drop assignments from sequences with no hits to equally-assigned sequences 

### DIFF
--- a/docs/src/test/scala/dropInconsistentAssignments.scala.md
+++ b/docs/src/test/scala/dropInconsistentAssignments.scala.md
@@ -122,7 +122,7 @@ Note that the previous filters guarantee that the mg7 LCA IDs *are* in the NCBI 
             lcaParent => {
 ```
 
-Here we discard those taxa whose lineage does **not** contain the *parent* of the lca assignment.
+### Here we discard (from the query sequence data) those taxa assigned whose lineage does **not** contain the *parent* of the lca assignment (obtained in the MG7 test).
 
 ```scala
               val (acceptedTaxas, rejectedTaxas) =

--- a/src/test/scala/dropInconsistentAssignments.scala
+++ b/src/test/scala/dropInconsistentAssignments.scala
@@ -60,7 +60,7 @@
   1. We run MG7 with input the output from the drop redundant assignments step, and as reference database the same but the sequence we are using as query.
   2. For each sequence we check the relation of its assignments with the corresponding LCA that we've got from MG7. If some assignment is too far away from the LCA in the taxonomic tree, it is discarded. After this step the BLAST database is generated again.
 
-  Almost all `99.8%` of the sequences from the drop redundant assignments step pass  this filter, because it's mostly about filtering out *wrong* assignments and there are not many sequences that get all assignments discarded.
+  Almost all `99.8%` of the sequences from the drop redundant assignments step pass this filter, because it's mostly about filtering out *wrong* assignments and there are not many sequences that get all assignments discarded.
 */
 package ohnosequences.db.rna16s.test
 

--- a/src/test/scala/dropNoHitsAssignments.scala
+++ b/src/test/scala/dropNoHitsAssignments.scala
@@ -10,6 +10,8 @@
 
   1. the size of `rep(t)` is at least 2 (so that we can meaningfully compare something)
   2. `s` is not in `mg7(rep(t))`
+
+  We can do something slightly different but mostly equivalent through the mg7 LCA assignment: For `rep(t)`, if there are *other* sequences in `rep(t)`, as 1. above, and at least one of them *does* have an mg7 assignment, then we need to drop those with *no* **mg7** assignment.
 */
 package ohnosequences.db.rna16s.test
 
@@ -17,14 +19,56 @@ import ohnosequences.db._, csvUtils._, collectionUtils._
 import ohnosequences.ncbitaxonomy._, titan._
 import ohnosequences.fastarious.fasta._
 import ohnosequences.statika._
-import ohnosequences.mg7._
 import ohnosequences.awstools.s3._
 import com.amazonaws.auth._
 import com.amazonaws.services.s3.transfer._
 import com.github.tototoshi.csv._
 import better.files._
 
-case object dropNoHitsAssignments extends FilterDataFrom(dropInconsistentAssignments)(deps = mg7results, ncbiTaxonomyBundle) {
+case object dropNoHitsAssignments extends FilterDataFrom(dropInconsistentAssignments)(deps = mg7results) {
 
-  def filterData(): Unit = ()
+  type ID     = String
+  type Taxon  = String
+  type Fasta  = FASTA.Value
+
+  /* Mapping of sequence IDs to the list of their taxonomic assignments */
+  // id1 -> taxa1, taxa2, taxa3
+  // id2 -> taxa2, taxa4
+  // ...
+  lazy val assignments: Map[ID, Seq[Taxon]] = source.table.csvReader.iterator
+  .foldLeft(Map[ID, Seq[Taxon]]()) { (acc, row) =>
+    acc.updated(
+      row(0),
+      row(1).split(';').map(_.trim).toSeq
+    )
+  }
+  /* Transposed mapping of taxas to the sequence IDs that have this assignment; `rep` from the docs above. */
+  // taxa1 -> id1
+  // taxa2 -> id1, id2
+  // taxa3 -> id1
+  // taxa4 -> id2
+  // ...
+  lazy val assignedTo: Map[Taxon, Seq[ID]] = assignments.trans
+
+  lazy val mg7Assignment: Map[ID, Taxon] = dropInconsistentAssignments mg7LCAfromFile mg7results.lcaTable
+
+
+  def filterData(): Unit = {
+
+    assignedTo foreach {
+      // ids = rep(taxon)
+      case (taxon, ids) => if (ids.size >= 2) {
+
+        ids foreach { id =>
+          if( ids.exists(mg7Assignment.contains(_)) && (!mg7Assignment.contains(id)) ) {
+            // drop assignment
+          } else {
+            // keep assignment
+          }
+        }
+      }
+    }
+
+    ()
+  }
 }

--- a/src/test/scala/dropNoHitsAssignments.scala
+++ b/src/test/scala/dropNoHitsAssignments.scala
@@ -1,0 +1,30 @@
+/*
+  # Drop no-hits assignments
+
+  With
+
+  1. `rep(t)` the sequences with assignment set containing `t`
+  2. `mg7(seqs)` the union of the sequences appearing in the set of valid hits for each sequence in `seqs`
+
+  Then we drop from `rep(t)` those assignments `s -> t` for which
+
+  1. the size of `rep(t)` is at least 2 (so that we can meaningfully compare something)
+  2. `s` is not in `mg7(rep(t))`
+*/
+package ohnosequences.db.rna16s.test
+
+import ohnosequences.db._, csvUtils._, collectionUtils._
+import ohnosequences.ncbitaxonomy._, titan._
+import ohnosequences.fastarious.fasta._
+import ohnosequences.statika._
+import ohnosequences.mg7._
+import ohnosequences.awstools.s3._
+import com.amazonaws.auth._
+import com.amazonaws.services.s3.transfer._
+import com.github.tototoshi.csv._
+import better.files._
+
+case object dropNoHitsAssignments extends FilterDataFrom(dropInconsistentAssignments)(deps = mg7results, ncbiTaxonomyBundle) {
+
+  def filterData(): Unit = ()
+}


### PR DESCRIPTION
See #48 for context.

If, after dropping inconsistent assignments, we have 
1. a sequence `S1` with assignment `T`
2. other sequences `S2,S3,...` which all have a `T` assignment
3. `S1` has no BLAST hits with `S2,S3,...`

Then the `T` assignment should be dropped from `S1`

Note that we can do this with input the MG7 results and the output assignments of the "drop inconsistent assignments" step.
