### PR TITLE
NCBI-style FASTA headers are wrong

### DIFF
--- a/src/test/scala/pick16SCandidates.scala
+++ b/src/test/scala/pick16SCandidates.scala
@@ -114,7 +114,7 @@ case object pick16SCandidates extends FilterData(
         } else
           rows.partition(predicate)
 
-      val extendedID: String = s"${commonID}|lcl|${ohnosequences.db.rna16s.dbName}"
+      val extendedID: String = s"gnl|${ohnosequences.db.rna16s.dbName}|${commonID}"
 
       writeOutput(
         extendedID,


### PR DESCRIPTION
Which implies that they will be incorrectly parsed by `makeblastdb`. They should be

``` scala
// see https://en.wikipedia.org/wiki/FASTA_format#Sequence_identifiers
def header(id: String, db_name: String): String = s"gnl|${db_name}|${id}"
```
