### PR TITLE
Reimplement pick16SCandidates in a fixed-memory fashion

### DIFF
--- a/src/test/scala/pick16SCandidates.scala
+++ b/src/test/scala/pick16SCandidates.scala
@@ -108,10 +108,11 @@ case object pick16SCandidates extends FilterData(
   implicit class IteratorOps[V](val iterator: Iterator[V]) extends AnyVal {
 
     /* Similar to the Stream's .groupBy, but assuming that groups are contiguous. Another difference is that it returns the key corresponding to each group. */
+    // NOTE: The original iterator should be discarded after calling this method
     def groupBy[K](getKey: V => K): Iterator[(K, Seq[V])] = new Iterator[(K, Seq[V])] {
       /* The definition is very straightforward: we keep the `rest` of values and on each `.next()` call bite off the longest prefix with the same key */
 
-      // NOTE: Buffered iterator has .head which doesn't pop it as .next
+      /* Buffered iterator allows to loo ahead without removing the next element */
       private val rest: BufferedIterator[V] = iterator.buffered
 
       @annotation.tailrec

--- a/src/test/scala/pick16SCandidates.scala
+++ b/src/test/scala/pick16SCandidates.scala
@@ -112,7 +112,7 @@ case object pick16SCandidates extends FilterData(
     def groupBy[K](getKey: V => K): Iterator[(K, Seq[V])] = new Iterator[(K, Seq[V])] {
       /* The definition is very straightforward: we keep the `rest` of values and on each `.next()` call bite off the longest prefix with the same key */
 
-      /* Buffered iterator allows to loo ahead without removing the next element */
+      /* Buffered iterator allows to look ahead without removing the next element */
       private val rest: BufferedIterator[V] = iterator.buffered
 
       @annotation.tailrec
@@ -122,6 +122,7 @@ case object pick16SCandidates extends FilterData(
         else acc
       }
 
+      // NOTE: this is so simple, because of the contiguous grouping assumpltion
       def hasNext: Boolean = rest.hasNext
 
       def next(): (K, Seq[V]) = {

--- a/src/test/scala/pick16SCandidates.scala
+++ b/src/test/scala/pick16SCandidates.scala
@@ -115,21 +115,23 @@ case object pick16SCandidates extends FilterData(
       /* Buffered iterator allows to look ahead without removing the next element */
       private val rest: BufferedIterator[V] = iterator.buffered
 
-      @annotation.tailrec
-      private def longestPrefix(key: K, acc: Seq[V]): Seq[V] = {
-        if ( rest.hasNext && getKey(rest.head) == key )
-          longestPrefix(key, rest.next() +: acc)
-        else acc
-      }
-
       // NOTE: this is so simple, because of the contiguous grouping assumpltion
       def hasNext: Boolean = rest.hasNext
 
       def next(): (K, Seq[V]) = {
         val key = getKey(rest.head)
 
-        key -> longestPrefix(key, Seq())
+        key -> groupOf(key)
       }
+
+      @annotation.tailrec
+      private def groupOf_rec(key: K, acc: Seq[V]): Seq[V] = {
+        if ( rest.hasNext && getKey(rest.head) == key )
+          groupOf_rec(key, rest.next() +: acc)
+        else acc
+      }
+
+      private def groupOf(key: K): Seq[V] = groupOf_rec(key, Seq())
     }
   }
 


### PR DESCRIPTION
Using `Iterable` instead of `Stream` and do some lazy `groupBy`. 
