### PR TITLE
Release 0.11.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ data/out/
 *.fasta
 *.tsv
 
+refdb.blast.csv
 ohnosequences.db.rna16s.csv
 blastdb/

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ resolvers := Seq(
   "Era7 private maven snapshots" at s3("private.snapshots.era7.com").toHttps(s3region.value.toString)
 ) ++ resolvers.value
 
-GithubRelease.repo := name.value
+GithubRelease.repo := "ohnosequences/db.rna16s"
 
 bucketSuffix  := "era7.com"
 

--- a/notes/0.11.0.markdown
+++ b/notes/0.11.0.markdown
@@ -1,0 +1,7 @@
+This release changes both the data generated and its structure.
+
+- #52 FASTA headers now are `gnl|${db_name}|${id}`, following NCBI conventions
+- #49 sequences with a significant number of `N`s are excluded
+- #50 down to requiring 99% of query coverage in the drop inconsistent assignments step
+
+Apart from this there are various documentation improvements.

--- a/src/test/scala/pick16SCandidates.scala
+++ b/src/test/scala/pick16SCandidates.scala
@@ -116,7 +116,7 @@ case object pick16SCandidates extends FilterData(
         sys.error(s"ID [${commonID}] is not found in the FASTA. Check RNACentral filtering.")
 
       val (acceptedRows, rejectedRows) =
-        if ( sequencePredicate(fasta.getV(sequence)) ) {
+        if ( sequencePredicate( (fasta get sequence).value ) ) {
           /* if the sequence is OK, we partition the rows based on the predicate */
           rows.partition(rowPredicate)
         } else {


### PR DESCRIPTION
After #52 and specially #49 and #50, which where identified in #48, we are pretty happy with the current pipeline.

Let's release 0.11.0, I will check the data afterwards and then we can consider this stable.
