### PR TITLE
Modify final data filtering procedure

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ libraryDependencies ++= Seq(
   "ohnosequences" %% "ncbitaxonomy"  % "0.1.0",
   // Test:
   "era7bio"       %% "defaults" % "0.2.0"                      % Test,
-  "ohnosequences" %% "mg7"      % "1.0.0-M5-pr78-142-ga95095e" % Test
+  "ohnosequences" %% "mg7"      % "1.0.0-M5-pr78-143-g50f6e1e" % Test
 )
 
 // FIXME: update era7bio/defaults after loquat M9 release and remove this line:

--- a/build.sbt
+++ b/build.sbt
@@ -19,9 +19,12 @@ libraryDependencies ++= Seq(
   "ohnosequences" %% "blast-api"     % "0.7.0",
   "ohnosequences" %% "ncbitaxonomy"  % "0.1.0",
   // Test:
-  "era7bio"       %% "defaults" % "0.2.0"                     % Test,
-  "ohnosequences" %% "mg7"      % "1.0.0-M5-pr78-64-gd886636" % Test
+  "era7bio"       %% "defaults" % "0.2.0"                      % Test,
+  "ohnosequences" %% "mg7"      % "1.0.0-M5-pr78-139-g91401e1" % Test
 )
+
+// FIXME: update era7bio/defaults after loquat M9 release and remove this line:
+dependencyOverrides += "ohnosequences" %% "loquat" % "2.0.0-M8-11-g820cfe6"
 
 dependencyOverrides ++= Set(
   "org.apache.httpcomponents" % "httpclient" % "4.5.1",

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ libraryDependencies ++= Seq(
   "ohnosequences" %% "ncbitaxonomy"  % "0.1.0",
   // Test:
   "era7bio"       %% "defaults" % "0.2.0"                      % Test,
-  "ohnosequences" %% "mg7"      % "1.0.0-M5-pr78-139-g91401e1" % Test
+  "ohnosequences" %% "mg7"      % "1.0.0-M5-pr78-142-ga95095e" % Test
 )
 
 // FIXME: update era7bio/defaults after loquat M9 release and remove this line:

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -8,36 +8,34 @@ Here is the sequence of bundles you have to launch to repeat the whole DB genera
 2. Then launch `sbt test:console` and run commands in it; for each bundle you can choose EC2 instance type in [`src/test/scala/runBundles.scala`](src/test/scala/runBundles.scala)
 
 1. `pick16SCandidates`
-  - Recommended EC2 instance type: `r3.x4large`, it has over 100GB RAM (we need a lot for the GC, because we load _everything_ in memory; see [#47](https://github.com/ohnosequences/db.rna16s/issues/47))
-  - Approximate running time: several hours
-  - Command: `ohnosequences.db.rna16s.test.rna16s.pick16SCandidates(your_user.AWSUser)`.  
-    It returns you the instance ID. You have to terminate it **manually**.
+   - Recommended EC2 instance type: `r3.x4large`, it has over 100GB RAM (we need a lot for the GC, because we load _everything_ in memory; see [#47](https://github.com/ohnosequences/db.rna16s/issues/47))
+   - Approximate running time: several hours
+   - Command: `ohnosequences.db.rna16s.test.rna16s.pick16SCandidates(your_user.AWSUser)`.  
+     It returns you the instance ID. You have to terminate it **manually**.
 
 2. `dropRedundantAssignments`
-  - Recommended EC2 instance type: `r3.large` or `m3.xlarge`
-  - Approximate run time: 10-20 minutes
-  - Command: `ohnosequences.db.rna16s.test.rna16s.dropRedundantAssignmentsAndGenerate(your_user.AWSUser)`.  
-    It returns you the instance ID. You have to terminate it **manually**.
+   - Recommended EC2 instance type: `r3.large` or `m3.xlarge`
+   - Approximate run time: 10-20 minutes
+   - Command: `ohnosequences.db.rna16s.test.rna16s.dropRedundantAssignmentsAndGenerate(your_user.AWSUser)`.  
+     It returns you the instance ID. You have to terminate it **manually**.
 
 3. MG7 + `dropInconsistentAssignments`
-  1. First you need to run all the steps of the MG7 pipeline (one after another, not all at once):
+   * First you need to run all the steps of the MG7 pipeline (one after another, not all at once):
 
-    ```scala
-    > ohnosequences.db.rna16s.test.referenceDBPipeline.splitLoquat.deploy(your_user)
-    > ohnosequences.db.rna16s.test.referenceDBPipeline.blastLoquat.deploy(your_user)
-    > ohnosequences.db.rna16s.test.referenceDBPipeline.assignLoquat.deploy(your_user)
-    > ohnosequences.db.rna16s.test.referenceDBPipeline.mergeLoquat.deploy(your_user)
-    ```
+     ```scala
+     >  ohnosequences.db.rna16s.test.mg7.pipeline.split.deploy(your_user)
+     >  ohnosequences.db.rna16s.test.mg7.pipeline.blast.deploy(your_user)
+     ```
 
-    Each loquat will offer you to subscribe to the notifications and tell you when it finished.
+     Each loquat will offer you to subscribe to the  notifications and tell you when it finished.
 
-  2. Then run `dropInconsistentAssignments`:
-    - Recommended EC2 instance type: `r3.large` or `m3.xlarge`
-    - Approximate run time: 10-20 minutes
-    - Command: `ohnosequences.db.rna16s.test.rna16s.dropInconsistentAssignmentsAndGenerate(your_user.AWSUser)`.  
-    It returns you the instance ID. You have to terminate it **manually**.
+   * Then run `dropInconsistentAssignments`:
+     - Recommended EC2 instance type: `r3.large` or `m3.xlarge`
+     - Approximate run time: 10-20 minutes
+     - Command:  `ohnosequences.db.rna16s.test.rna16s.dropInconsistentAssi gnmentsAndGenerate(your_user.AWSUser)`.  
+     It returns you the instance ID. You have to terminate it  **manually**.
 
 4. `releaseData`
-  - This is not a bundle, just a function that you call locally and it copies objects in S3
-  - Approximate run time: ~1 minute
-  - Command: `ohnosequences.db.rna16s.test.releaseData(your_user.AWSUser.profile)`
+   - This is not a bundle, just a function that you call locally and it copies objects in S3
+   - Approximate run time: ~1 minute
+   - Command: `ohnosequences.db.rna16s.test.releaseData(your_user.AWSUser.profile)`

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -42,7 +42,7 @@ Here is the sequence of bundles you have to launch to repeat the whole DB genera
 
 6. `clusterSequences`:
    - Recommended EC2 instance type: `r3.large` or `m3.medium` (doesn't require much resources)
-   - Approximate run time:
+   - Approximate run time: ~1 hour 20-40 minutes
    - Command:  
       ```scala
       ohnosequences.db.rna16s.test.rna16s.clusterSequences(your_user.AWSUser)

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -7,35 +7,62 @@ Here is the sequence of bundles you have to launch to repeat the whole DB genera
 1. First of all you need to publish an fat-jar artifact with `sbt publish`
 2. Then launch `sbt test:console` and run commands in it; for each bundle you can choose EC2 instance type in [`src/test/scala/runBundles.scala`](src/test/scala/runBundles.scala)
 
-1. `pick16SCandidates`
+3. `pick16SCandidates`
    - Recommended EC2 instance type: `r3.x4large`, it has over 100GB RAM (we need a lot for the GC, because we load _everything_ in memory; see [#47](https://github.com/ohnosequences/db.rna16s/issues/47))
    - Approximate running time: several hours
-   - Command: `ohnosequences.db.rna16s.test.rna16s.pick16SCandidates(your_user.AWSUser)`.  
-     It returns you the instance ID. You have to terminate it **manually**.
+   - Command:
 
-2. `dropRedundantAssignments`
+      ```scala
+      ohnosequences.db.rna16s.test.rna16s.pick16SCandidates(your_user.AWSUser)
+      ```
+      It returns you the instance ID. You have to terminate it **manually**.
+
+4. `dropRedundantAssignments`
    - Recommended EC2 instance type: `r3.large` or `m3.xlarge`
    - Approximate run time: 10-20 minutes
-   - Command: `ohnosequences.db.rna16s.test.rna16s.dropRedundantAssignmentsAndGenerate(your_user.AWSUser)`.  
-     It returns you the instance ID. You have to terminate it **manually**.
-
-3. MG7 + `dropInconsistentAssignments`
-   * First you need to run all the steps of the MG7 pipeline (one after another, not all at once):
+   - Command:
 
      ```scala
-     >  ohnosequences.db.rna16s.test.mg7.pipeline.split.deploy(your_user)
-     >  ohnosequences.db.rna16s.test.mg7.pipeline.blast.deploy(your_user)
+     ohnosequences.db.rna16s.test.rna16s.dropRedundantAssignmentsAndGenerate(your_user.AWSUser)
      ```
+     It returns you the instance ID. You have to terminate it **manually**.
 
-     Each loquat will offer you to subscribe to the  notifications and tell you when it finished.
+5. MG7:
+   - First run split step
+      ```scala
+      ohnosequences.db.rna16s.test.mg7.pipeline.split.deploy(your_user)
+      ```
 
-   * Then run `dropInconsistentAssignments`:
-     - Recommended EC2 instance type: `r3.large` or `m3.xlarge`
-     - Approximate run time: 10-20 minutes
-     - Command:  `ohnosequences.db.rna16s.test.rna16s.dropInconsistentAssi gnmentsAndGenerate(your_user.AWSUser)`.  
-     It returns you the instance ID. You have to terminate it  **manually**.
+   - Then wait for it to finish and run BLAST
+      ```scala
+      ohnosequences.db.rna16s.test.mg7.pipeline.blast.deploy(your_user)
+      ```
 
-4. `releaseData`
+      Each loquat will offer you to subscribe to the notifications and tell you when it finished. They will terminate on success automatically.
+
+6. `clusterSequences`:
+   - Recommended EC2 instance type: `r3.large` or `m3.medium` (doesn't require much resources)
+   - Approximate run time:
+   - Command:  
+      ```scala
+      ohnosequences.db.rna16s.test.rna16s.clusterSequences(your_user.AWSUser)
+      ```
+      It returns you the instance ID. You have to terminate it  **manually**.
+
+7. `dropInconsistentAssignments`:
+   - Recommended EC2 instance type: `r3.large` or `m3.xlarge`
+   - Approximate run time: 10-20 minutes
+   - Command:  
+      ```scala
+      ohnosequences.db.rna16s.test.rna16s.dropInconsistentAssignmentsAndGenerate(your_user.AWSUser)
+      ```
+      It returns you the instance ID. You have to terminate it  **manually**.
+
+8. `releaseData`
    - This is not a bundle, just a function that you call locally and it copies objects in S3
    - Approximate run time: ~1 minute
-   - Command: `ohnosequences.db.rna16s.test.releaseData(your_user.AWSUser.profile)`
+   - Command:
+      ```scala
+      ohnosequences.db.rna16s.test.releaseData(your_user.AWSUser.profile)
+      ```
+      It returns you the instance ID. You have to terminate it  **manually**.

--- a/docs/src/main/scala/package.scala.md
+++ b/docs/src/main/scala/package.scala.md
@@ -29,12 +29,14 @@ package object rna16s {
 
 
 
-[test/scala/dropRedundantAssignments.scala]: ../../test/scala/dropRedundantAssignments.scala.md
-[test/scala/runBundles.scala]: ../../test/scala/runBundles.scala.md
-[test/scala/mg7pipeline.scala]: ../../test/scala/mg7pipeline.scala.md
-[test/scala/compats.scala]: ../../test/scala/compats.scala.md
-[test/scala/dropInconsistentAssignments.scala]: ../../test/scala/dropInconsistentAssignments.scala.md
-[test/scala/pick16SCandidates.scala]: ../../test/scala/pick16SCandidates.scala.md
-[test/scala/releaseData.scala]: ../../test/scala/releaseData.scala.md
 [main/scala/package.scala]: package.scala.md
 [main/scala/release.scala]: release.scala.md
+[test/scala/clusterSequences.scala]: ../../test/scala/clusterSequences.scala.md
+[test/scala/compats.scala]: ../../test/scala/compats.scala.md
+[test/scala/dropInconsistentAssignments.scala]: ../../test/scala/dropInconsistentAssignments.scala.md
+[test/scala/dropRedundantAssignments.scala]: ../../test/scala/dropRedundantAssignments.scala.md
+[test/scala/mg7pipeline.scala]: ../../test/scala/mg7pipeline.scala.md
+[test/scala/package.scala]: ../../test/scala/package.scala.md
+[test/scala/pick16SCandidates.scala]: ../../test/scala/pick16SCandidates.scala.md
+[test/scala/releaseData.scala]: ../../test/scala/releaseData.scala.md
+[test/scala/runBundles.scala]: ../../test/scala/runBundles.scala.md

--- a/docs/src/main/scala/release.scala.md
+++ b/docs/src/main/scala/release.scala.md
@@ -16,12 +16,14 @@ case object data {
 
 
 
-[test/scala/dropRedundantAssignments.scala]: ../../test/scala/dropRedundantAssignments.scala.md
-[test/scala/runBundles.scala]: ../../test/scala/runBundles.scala.md
-[test/scala/mg7pipeline.scala]: ../../test/scala/mg7pipeline.scala.md
-[test/scala/compats.scala]: ../../test/scala/compats.scala.md
-[test/scala/dropInconsistentAssignments.scala]: ../../test/scala/dropInconsistentAssignments.scala.md
-[test/scala/pick16SCandidates.scala]: ../../test/scala/pick16SCandidates.scala.md
-[test/scala/releaseData.scala]: ../../test/scala/releaseData.scala.md
 [main/scala/package.scala]: package.scala.md
 [main/scala/release.scala]: release.scala.md
+[test/scala/clusterSequences.scala]: ../../test/scala/clusterSequences.scala.md
+[test/scala/compats.scala]: ../../test/scala/compats.scala.md
+[test/scala/dropInconsistentAssignments.scala]: ../../test/scala/dropInconsistentAssignments.scala.md
+[test/scala/dropRedundantAssignments.scala]: ../../test/scala/dropRedundantAssignments.scala.md
+[test/scala/mg7pipeline.scala]: ../../test/scala/mg7pipeline.scala.md
+[test/scala/package.scala]: ../../test/scala/package.scala.md
+[test/scala/pick16SCandidates.scala]: ../../test/scala/pick16SCandidates.scala.md
+[test/scala/releaseData.scala]: ../../test/scala/releaseData.scala.md
+[test/scala/runBundles.scala]: ../../test/scala/runBundles.scala.md

--- a/docs/src/test/scala/clusterSequences.scala.md
+++ b/docs/src/test/scala/clusterSequences.scala.md
@@ -1,0 +1,212 @@
+
+```scala
+package ohnosequences.db.rna16s.test
+
+import ohnosequences.db._, csvUtils._, collectionUtils._
+import ohnosequences.fastarious.fasta._
+import ohnosequences.statika._
+import ohnosequences.mg7._
+import ohnosequences.awstools.s3._
+import com.amazonaws.auth._
+import com.amazonaws.services.s3.transfer._
+import ohnosequences.blast.api._, outputFields._
+import com.github.tototoshi.csv._
+import better.files._
+```
+
+
+# Sequences clustering
+
+The idea of this procedure is to split all sequences on equivalence classes based on their BLAST-similarity. So we take the results of MG7-BLAST run on the DB itself and then process the hits constructing a reflecsive, symmetric and transitive relation.
+
+For example, we have following hits:
+
+| Sequence | Hits       |
+|:--------:|:-----------|
+|   `a3`   | `a2`       |
+|   `b1`   |            |
+|   `a2`   | `a1`       |
+|   `a1`   | `a2`, `a3` |
+|   `b3`   |            |
+|   `b2`   | `b1`, `b3` |
+
+Then we consider every hit as the evidence of relation between the given elements:
+
+* `a3 → a2` therefore `a2 → a3` (symmetry)
+* also `a2 → a1`, so `a3 → a1` (transitivity)
+
+So the clasters that we should get from this are
+
+* `{ a1, a2, a3 }`
+* `{ b1, b2, b3 }`
+
+
+```scala
+case object clusterSequences extends Bundle(mg7BlastResults) { bundle =>
+
+  lazy val name: String = "clusters"
+
+  final lazy val s3: S3Folder = ohnosequences.db.rna16s.s3prefix / name /
+  final lazy val outputName: String = name + ".csv"
+
+
+  case object output {
+    lazy val file: File   = File(outputName).createIfNotExists()
+    lazy val s3: S3Object = bundle.s3 / outputName
+
+    lazy val csv = CSVWriter.open(this.file.toJava, append = true)(csvUtils.UnixCSVFormat)
+
+    def upload() = {
+
+      val transferManager = new TransferManager(new InstanceProfileCredentialsProvider())
+
+      transferManager.upload(
+        this.s3.bucket, this.s3.key,
+        this.file.toJava
+      ).waitForCompletion
+
+      transferManager.shutdownNow()
+    }
+  }
+```
+
+This is the key method for the clustring pocedure.
+If we already have some clusters
+
+* `{ b1 }
+* `{ a3, a2 }`
+* `{ b3, b4 }`
+
+and want to add a new set of equivalent elements `{b2, b1, b3}`, then we need to filter out all clusters that intersect with this set (`{ b1 }` and `{ b3, b4 }`), union them all in one new class and add to the rest of the clusters:
+
+* `{ b1, b2, b3, b4 }`
+* `{ a3, a3 }`
+
+
+```scala
+  def addCluster(cluster: Set[ID], acc: List[Set[ID]]): List[Set[ID]] = {
+
+    val (related, rest) = acc.partition { _.intersect(cluster).nonEmpty }
+    val newCluster = (cluster :: related).reduce { _ union _ }
+
+    newCluster :: rest
+  }
+```
+
+This method folds over the hits applying `addCluster`
+
+```scala
+  def clusters(correspondences: Iterator[Set[ID]]): List[Set[ID]] =
+    correspondences.foldLeft(List[Set[ID]]()) {
+      case (acc: List[Set[ID]], (ids: Set[ID])) =>
+        addCluster(ids, acc)
+    }
+
+  type BlastRow = csv.Row[mg7.parameters.blastOutRec.Keys]
+
+  def instructions: AnyInstructions = {
+
+    LazyTry {
+
+      val blastReader = csv.Reader(mg7.parameters.blastOutRec.keys)(mg7BlastResults.blastResult)
+
+      val correspondences: Iterator[Set[ID]] = blastReader.rows
+        // grouping rows by the query sequence id
+        .contiguousGroupBy { _.select(qseqid) }
+        .map { case (qseq: ID, hits: Seq[BlastRow]) =>
+
+          hits.map{ _.select(sseqid) }.toSet + qseq
+        }
+
+      clusters(correspondences).foreach { ids => output.csv.writeRow(ids.toSeq) }
+
+    } -&-
+    LazyTry {
+      println("Uploading the results...")
+      output.upload()
+    } -&-
+    say(s"Clustered sequences uploaded to [${output.s3}]")
+
+  }
+
+}
+```
+
+This bundle just downloads the results of the `clusterSequences` bundle work
+
+```scala
+case object clusteringResults extends Bundle() {
+
+  lazy val s3location: S3Object = clusterSequences.output.s3
+  lazy val clusters: File = File(s3location.key).createIfNotExists()
+
+  def instructions: AnyInstructions = LazyTry {
+    val transferManager = new TransferManager(new InstanceProfileCredentialsProvider())
+
+    transferManager.download(
+      s3location.bucket, s3location.key,
+      clusters.toJava
+    ).waitForCompletion
+
+    transferManager.shutdownNow()
+  } -&-
+  say(s"Clusters downloaded to ${clusters}")
+}
+```
+
+## Tests
+
+```scala
+case object ClusteringTestCtx {
+
+  val hits: List[Set[ID]] = List(
+    Set("a1", "a2", "a3"),
+    Set("a2", "a1", "a4"),
+    Set("a3", "a2"),
+    Set("a4"),
+
+    Set("b1", "b2"),
+    Set("b2", "b1"),
+
+    Set("c1"),
+    Set("c3"),
+    Set("c2", "c1", "c3")
+  )
+}
+
+class ClusteringTest extends org.scalatest.FunSuite {
+  import ClusteringTestCtx._
+  import clusterSequences._
+
+  test("clustering") {
+
+    val abc = clusters(hits.toIterator)
+    info(abc.mkString("\n"))
+
+    assertResult( List() ) {
+
+      abc diff List(
+        Set("a1", "a2", "a3", "a4"),
+        Set("b1", "b2"),
+        Set("c1", "c2", "c3")
+      )
+    }
+  }
+}
+
+```
+
+
+
+
+[main/scala/package.scala]: ../../main/scala/package.scala.md
+[main/scala/release.scala]: ../../main/scala/release.scala.md
+[test/scala/clusterSequences.scala]: clusterSequences.scala.md
+[test/scala/compats.scala]: compats.scala.md
+[test/scala/dropInconsistentAssignments.scala]: dropInconsistentAssignments.scala.md
+[test/scala/dropRedundantAssignments.scala]: dropRedundantAssignments.scala.md
+[test/scala/mg7pipeline.scala]: mg7pipeline.scala.md
+[test/scala/package.scala]: package.scala.md
+[test/scala/pick16SCandidates.scala]: pick16SCandidates.scala.md
+[test/scala/releaseData.scala]: releaseData.scala.md
+[test/scala/runBundles.scala]: runBundles.scala.md

--- a/docs/src/test/scala/clusterSequences.scala.md
+++ b/docs/src/test/scala/clusterSequences.scala.md
@@ -73,7 +73,7 @@ case object clusterSequences extends Bundle(mg7BlastResults) { bundle =>
 This is the key method for the clustring pocedure.
 If we already have some clusters
 
-* `{ b1 }
+* `{ b1 }`
 * `{ a3, a2 }`
 * `{ b3, b4 }`
 
@@ -154,7 +154,7 @@ case object clusteringResults extends Bundle() {
 }
 ```
 
-## Tests
+## A little test
 
 ```scala
 case object ClusteringTestCtx {

--- a/docs/src/test/scala/compats.scala.md
+++ b/docs/src/test/scala/compats.scala.md
@@ -16,10 +16,17 @@ case object compats {
     ohnosequences.generated.metadata.db_rna16s
   )
 
-  case object pick16SCandidates extends DefaultCompatible(ohnosequences.db.rna16s.test.pick16SCandidates, javaHeap = 80)
+  case object pick16SCandidates extends
+    DefaultCompatible(ohnosequences.db.rna16s.test.pick16SCandidates, javaHeap = 50)
 
-  case object dropRedundantAssignmentsAndGenerate extends DefaultCompatible(ohnosequences.db.rna16s.test.dropRedundantAssignmentsAndGenerate, javaHeap = 10)
-  case object dropInconsistentAssignmentsAndGenerate extends DefaultCompatible(ohnosequences.db.rna16s.test.dropInconsistentAssignmentsAndGenerate, javaHeap = 10)
+  case object dropRedundantAssignmentsAndGenerate extends
+    DefaultCompatible(ohnosequences.db.rna16s.test.dropRedundantAssignmentsAndGenerate, javaHeap = 10)
+
+  case object clusterSequences extends
+    DefaultCompatible(ohnosequences.db.rna16s.test.clusterSequences, javaHeap = 10)
+
+  case object dropInconsistentAssignmentsAndGenerate extends
+    DefaultCompatible(ohnosequences.db.rna16s.test.dropInconsistentAssignmentsAndGenerate, javaHeap = 10)
 }
 
 ```
@@ -27,12 +34,14 @@ case object compats {
 
 
 
-[test/scala/dropRedundantAssignments.scala]: dropRedundantAssignments.scala.md
-[test/scala/runBundles.scala]: runBundles.scala.md
-[test/scala/mg7pipeline.scala]: mg7pipeline.scala.md
-[test/scala/compats.scala]: compats.scala.md
-[test/scala/dropInconsistentAssignments.scala]: dropInconsistentAssignments.scala.md
-[test/scala/pick16SCandidates.scala]: pick16SCandidates.scala.md
-[test/scala/releaseData.scala]: releaseData.scala.md
 [main/scala/package.scala]: ../../main/scala/package.scala.md
 [main/scala/release.scala]: ../../main/scala/release.scala.md
+[test/scala/clusterSequences.scala]: clusterSequences.scala.md
+[test/scala/compats.scala]: compats.scala.md
+[test/scala/dropInconsistentAssignments.scala]: dropInconsistentAssignments.scala.md
+[test/scala/dropRedundantAssignments.scala]: dropRedundantAssignments.scala.md
+[test/scala/mg7pipeline.scala]: mg7pipeline.scala.md
+[test/scala/package.scala]: package.scala.md
+[test/scala/pick16SCandidates.scala]: pick16SCandidates.scala.md
+[test/scala/releaseData.scala]: releaseData.scala.md
+[test/scala/runBundles.scala]: runBundles.scala.md

--- a/docs/src/test/scala/mg7pipeline.scala.md
+++ b/docs/src/test/scala/mg7pipeline.scala.md
@@ -2,7 +2,7 @@
 ```scala
 package ohnosequences.db.rna16s.test
 
-import ohnosequences.mg7._, loquats._, dataflows._
+import ohnosequences.mg7._, loquats._
 import ohnosequences.datasets._, illumina._
 import ohnosequences.cosas._, types._, klists._
 import ohnosequences.loquat._, utils._
@@ -19,7 +19,7 @@ import com.amazonaws.auth._, profile._
 
 import better.files._
 
-case object referenceDBPipeline {
+case object mg7 {
 ```
 
 As the reference database we use the one generated from dropRedundantAssignments
@@ -30,20 +30,8 @@ As the reference database we use the one generated from dropRedundantAssignments
     dropRedundantAssignmentsAndGenerate.s3,
     dropRedundantAssignments.output.table.s3
   )
-```
 
-As input we use the FASTA accepted by dropRedundantAssignments
-
-```scala
-  val splitInputs: Map[ID, S3Resource] = Map(
-    "refdb" -> S3Resource(ohnosequences.db.rna16s.test.dropRedundantAssignments.output.fasta.s3)
-  )
-
-  def outputS3Folder(step: String): S3Folder = ohnosequences.db.rna16s.s3prefix / "mg7" / step /
-
-  case object mg7parameters extends MG7Parameters(
-    (_, step) => outputS3Folder(step),
-    readsLength = bp250, // NOTE: this does not have any influence
+  case object parameters extends MG7Parameters(
     splitChunkSize = 100,
     splitInputFormat = FastaInput,
     blastCommand = blastn,
@@ -57,8 +45,7 @@ As input we use the FASTA accepted by dropRedundantAssignments
       *[AnyDenotation]
     ).value,
     referenceDBs = Set(rna16sRefDB)
-  )
-  {
+  ) {
 ```
 
 The only basic thing we require is at least 99% **query** coverage.
@@ -74,96 +61,58 @@ IMPORTANT: exclude the query from the results
       ( row.select(outputFields.qseqid) != row.select(outputFields.sseqid) )
   }
 
-  lazy val dataflow = NoFlashDataflow(mg7parameters)(splitInputs)
-```
-
-This class is a default loquat configuration for this pipeline
-
-```scala
-  abstract class RefDBLoquatConfig(
-    val loquatName: String,
-    val dataMappings: List[AnyDataMapping],
-    val workersNumber: Int = 1
-  ) extends AnyLoquatConfig {
+  case object pipeline extends MG7Pipeline(parameters) {
 
     val metadata: AnyArtifactMetadata = ohnosequences.generated.metadata.db_rna16s
-
     // TODO: we should probably have a restricted role for this:
     val iamRoleName: String = "era7-projects"
     val logsBucketName: String = "era7-projects-loquats"
-
-    val defaultAMI = AmazonLinuxAMI(Ireland, HVM, InstanceStore)
-
-    val managerConfig: AnyManagerConfig = ManagerConfig(
-      InstanceSpecs(defaultAMI, m3.medium),
-      purchaseModel = Spot(maxPrice = Some(0.01))
-    )
-
-    val workersConfig: AnyWorkersConfig = WorkersConfig(
-      instanceSpecs = InstanceSpecs(defaultAMI, m3.medium),
-      purchaseModel = Spot(maxPrice = Some(0.02)),
-      groupSize = AutoScalingGroupSize(0, workersNumber, workersNumber*2)
-    )
-
-    val terminationConfig = TerminationConfig(
-      terminateAfterInitialDataMappings = true
-    )
-  }
 ```
 
-
-### mg7 steps
-
-These objects define the mg7 pipeline steps. You need to run them in the order they are written here.
-
-For running them, go to the scala console and run
-
-```
-ohnosequences.db.rna16s.referenceDBPipeline.<name>Loquat.deploy(era7.defaults.<yourUser>)
-```
-
+As input we use the FASTA accepted by dropRedundantAssignments
 
 ```scala
-  case object splitConfig extends RefDBLoquatConfig("split", dataflow.splitDataMappings)
-  case object splitLoquat extends Loquat(splitConfig, splitDataProcessing(mg7parameters))
-
-  case object blastConfig extends RefDBLoquatConfig("blast", dataflow.blastDataMappings, 100) {
-    // NOTE: we don't want to check input objects here because they are too many and
-    //   checking them one by one will take too long and likely fail
-    override val checkInputObjects = false
-
-    override val workersConfig: AnyWorkersConfig = WorkersConfig(
-      instanceSpecs = InstanceSpecs(defaultAMI, c3.large),
-      purchaseModel = Spot(maxPrice = Some(0.03)),
-      groupSize = AutoScalingGroupSize(0, workersNumber, workersNumber)
+    lazy val inputSamples: Map[ID, S3Resource] = Map(
+      "refdb" -> S3Resource(ohnosequences.db.rna16s.test.dropRedundantAssignments.output.fasta.s3)
     )
+
+    lazy val outputS3Folder: (SampleID, StepName) => S3Folder = { (_, stepName) =>
+      ohnosequences.db.rna16s.s3prefix / "mg7" / stepName /
+    }
+
+    val splitConfig  = SplitConfig(1)
+    val blastConfig  = BlastConfig(100)
+    // these steps are not needed:
+    val assignConfig = AssignConfig(10)
+    val mergeConfig  = MergeConfig(1)
+    val countConfig  = CountConfig(1)
   }
-  case object blastLoquat extends Loquat(blastConfig, blastDataProcessing(mg7parameters))
+}
+```
 
+This bundle just downloads the output of the MG7 Blast step and merges the chunks
 
-  case object assignConfig extends RefDBLoquatConfig("assign", dataflow.assignDataMappings, 10) {
-    override val checkInputObjects = false
+```scala
+case object mg7BlastResults extends Bundle() {
 
-    override lazy val amiEnv = amznAMIEnv(ami, javaHeap = 10)
+  lazy val s3location: S3Folder = mg7.pipeline.outputS3Folder("", "blast") / "chunks" /
 
-    override val workersConfig: AnyWorkersConfig = WorkersConfig(
-      instanceSpecs = InstanceSpecs(defaultAMI, m3.xlarge),
-      purchaseModel = Spot(maxPrice = Some(0.03)),
-      groupSize = AutoScalingGroupSize(0, workersNumber, workersNumber)
-    )
+  lazy val blastChunks: File = File(s3location.key)
+  lazy val blastResult: File = (blastChunks.parent / "blastResult.csv").createIfNotExists()
+
+  def instructions: AnyInstructions = LazyTry {
+    val transferManager = new TransferManager(new InstanceProfileCredentialsProvider())
+
+    transferManager.downloadDirectory(
+      s3location.bucket, s3location.key,
+      File(".").toJava
+    ).waitForCompletion
+
+    transferManager.shutdownNow()
+  } -&- LazyTry {
+
+    loquats.mergeDataProcessing().mergeChunks(blastChunks, blastResult)
   }
-  case object assignLoquat extends Loquat(assignConfig, assignDataProcessing(mg7parameters))
-
-  case object mergeConfig extends RefDBLoquatConfig("merge", dataflow.mergeDataMappings) {
-    override val skipEmptyResults = false
-
-    override val workersConfig: AnyWorkersConfig = WorkersConfig(
-      instanceSpecs = InstanceSpecs(defaultAMI, c3.large),
-      purchaseModel = Spot(maxPrice = Some(0.03)),
-      groupSize = AutoScalingGroupSize(0, workersNumber, workersNumber*2)
-    )
-  }
-  case object mergeLoquat extends Loquat(mergeConfig, mergeDataProcessing)
 }
 
 ```
@@ -171,12 +120,14 @@ ohnosequences.db.rna16s.referenceDBPipeline.<name>Loquat.deploy(era7.defaults.<y
 
 
 
-[test/scala/dropRedundantAssignments.scala]: dropRedundantAssignments.scala.md
-[test/scala/runBundles.scala]: runBundles.scala.md
-[test/scala/mg7pipeline.scala]: mg7pipeline.scala.md
-[test/scala/compats.scala]: compats.scala.md
-[test/scala/dropInconsistentAssignments.scala]: dropInconsistentAssignments.scala.md
-[test/scala/pick16SCandidates.scala]: pick16SCandidates.scala.md
-[test/scala/releaseData.scala]: releaseData.scala.md
 [main/scala/package.scala]: ../../main/scala/package.scala.md
 [main/scala/release.scala]: ../../main/scala/release.scala.md
+[test/scala/clusterSequences.scala]: clusterSequences.scala.md
+[test/scala/compats.scala]: compats.scala.md
+[test/scala/dropInconsistentAssignments.scala]: dropInconsistentAssignments.scala.md
+[test/scala/dropRedundantAssignments.scala]: dropRedundantAssignments.scala.md
+[test/scala/mg7pipeline.scala]: mg7pipeline.scala.md
+[test/scala/package.scala]: package.scala.md
+[test/scala/pick16SCandidates.scala]: pick16SCandidates.scala.md
+[test/scala/releaseData.scala]: releaseData.scala.md
+[test/scala/runBundles.scala]: runBundles.scala.md

--- a/docs/src/test/scala/package.scala.md
+++ b/docs/src/test/scala/package.scala.md
@@ -1,0 +1,67 @@
+
+```scala
+package ohnosequences.db.rna16s
+
+import ohnosequences.fastarious.fasta._
+
+package object test {
+
+  type ID    = String
+  type Taxon = String
+  type Fasta = FASTA.Value
+
+  // TODO: move it to db.rnacentral
+  implicit class IteratorOps[V](val iterator: Iterator[V]) extends AnyVal {
+```
+
+Similar to the Stream's .groupBy, but assuming that groups are contiguous. Another difference is that it returns the key corresponding to each group.
+
+```scala
+    // NOTE: The original iterator should be discarded after calling this method
+    def contiguousGroupBy[K](getKey: V => K): Iterator[(K, Seq[V])] = new Iterator[(K, Seq[V])] {
+```
+
+The definition is very straightforward: we keep the `rest` of values and on each `.next()` call bite off the longest prefix with the same key
+Buffered iterator allows to look ahead without removing the next element
+
+```scala
+      private val rest: BufferedIterator[V] = iterator.buffered
+
+      // NOTE: this is so simple, because of the contiguous grouping assumpltion
+      def hasNext: Boolean = rest.hasNext
+
+      def next(): (K, Seq[V]) = {
+        val key = getKey(rest.head)
+
+        key -> groupOf(key)
+      }
+
+      @annotation.tailrec
+      private def groupOf_rec(key: K, acc: Seq[V]): Seq[V] = {
+        if ( rest.hasNext && getKey(rest.head) == key )
+          groupOf_rec(key, rest.next() +: acc)
+        else acc
+      }
+
+      private def groupOf(key: K): Seq[V] = groupOf_rec(key, Seq())
+    }
+  }
+
+}
+
+```
+
+
+
+
+[main/scala/package.scala]: ../../main/scala/package.scala.md
+[main/scala/release.scala]: ../../main/scala/release.scala.md
+[test/scala/clusterSequences.scala]: clusterSequences.scala.md
+[test/scala/compats.scala]: compats.scala.md
+[test/scala/dropInconsistentAssignments.scala]: dropInconsistentAssignments.scala.md
+[test/scala/dropRedundantAssignments.scala]: dropRedundantAssignments.scala.md
+[test/scala/mg7pipeline.scala]: mg7pipeline.scala.md
+[test/scala/package.scala]: package.scala.md
+[test/scala/pick16SCandidates.scala]: pick16SCandidates.scala.md
+[test/scala/releaseData.scala]: releaseData.scala.md
+[test/scala/runBundles.scala]: runBundles.scala.md

--- a/docs/src/test/scala/releaseData.scala.md
+++ b/docs/src/test/scala/releaseData.scala.md
@@ -62,12 +62,14 @@ This code generates a list of pairs for all objects in the source folder to the 
 
 
 
-[test/scala/dropRedundantAssignments.scala]: dropRedundantAssignments.scala.md
-[test/scala/runBundles.scala]: runBundles.scala.md
-[test/scala/mg7pipeline.scala]: mg7pipeline.scala.md
-[test/scala/compats.scala]: compats.scala.md
-[test/scala/dropInconsistentAssignments.scala]: dropInconsistentAssignments.scala.md
-[test/scala/pick16SCandidates.scala]: pick16SCandidates.scala.md
-[test/scala/releaseData.scala]: releaseData.scala.md
 [main/scala/package.scala]: ../../main/scala/package.scala.md
 [main/scala/release.scala]: ../../main/scala/release.scala.md
+[test/scala/clusterSequences.scala]: clusterSequences.scala.md
+[test/scala/compats.scala]: compats.scala.md
+[test/scala/dropInconsistentAssignments.scala]: dropInconsistentAssignments.scala.md
+[test/scala/dropRedundantAssignments.scala]: dropRedundantAssignments.scala.md
+[test/scala/mg7pipeline.scala]: mg7pipeline.scala.md
+[test/scala/package.scala]: package.scala.md
+[test/scala/pick16SCandidates.scala]: pick16SCandidates.scala.md
+[test/scala/releaseData.scala]: releaseData.scala.md
+[test/scala/runBundles.scala]: runBundles.scala.md

--- a/docs/src/test/scala/runBundles.scala.md
+++ b/docs/src/test/scala/runBundles.scala.md
@@ -29,11 +29,16 @@ case object rna16s {
   }
 
   def pick16SCandidates(user: AWSUser): List[String] =
-    launch(ohnosequences.db.rna16s.test.compats.pick16SCandidates, r3.x4large)(user)
+    launch(ohnosequences.db.rna16s.test.compats.pick16SCandidates, r3.x2large)(user)
 
-  def dropRedundantAssignmentsAndGenerate(user: AWSUser): List[String] = launch(ohnosequences.db.rna16s.test.compats.dropRedundantAssignmentsAndGenerate, r3.large)(user)
+  def dropRedundantAssignmentsAndGenerate(user: AWSUser): List[String] =
+    launch(ohnosequences.db.rna16s.test.compats.dropRedundantAssignmentsAndGenerate, r3.large)(user)
 
-  def dropInconsistentAssignmentsAndGenerate(user: AWSUser): List[String] = launch(ohnosequences.db.rna16s.test.compats.dropInconsistentAssignmentsAndGenerate, r3.large)(user)
+  def clusterSequences(user: AWSUser): List[String] =
+    launch(ohnosequences.db.rna16s.test.compats.clusterSequences, r3.large)(user)
+
+  def dropInconsistentAssignmentsAndGenerate(user: AWSUser): List[String] =
+    launch(ohnosequences.db.rna16s.test.compats.dropInconsistentAssignmentsAndGenerate, r3.large)(user)
 }
 
 ```
@@ -41,12 +46,14 @@ case object rna16s {
 
 
 
-[test/scala/dropRedundantAssignments.scala]: dropRedundantAssignments.scala.md
-[test/scala/runBundles.scala]: runBundles.scala.md
-[test/scala/mg7pipeline.scala]: mg7pipeline.scala.md
-[test/scala/compats.scala]: compats.scala.md
-[test/scala/dropInconsistentAssignments.scala]: dropInconsistentAssignments.scala.md
-[test/scala/pick16SCandidates.scala]: pick16SCandidates.scala.md
-[test/scala/releaseData.scala]: releaseData.scala.md
 [main/scala/package.scala]: ../../main/scala/package.scala.md
 [main/scala/release.scala]: ../../main/scala/release.scala.md
+[test/scala/clusterSequences.scala]: clusterSequences.scala.md
+[test/scala/compats.scala]: compats.scala.md
+[test/scala/dropInconsistentAssignments.scala]: dropInconsistentAssignments.scala.md
+[test/scala/dropRedundantAssignments.scala]: dropRedundantAssignments.scala.md
+[test/scala/mg7pipeline.scala]: mg7pipeline.scala.md
+[test/scala/package.scala]: package.scala.md
+[test/scala/pick16SCandidates.scala]: pick16SCandidates.scala.md
+[test/scala/releaseData.scala]: releaseData.scala.md
+[test/scala/runBundles.scala]: runBundles.scala.md

--- a/src/test/scala/clusterSequences.scala
+++ b/src/test/scala/clusterSequences.scala
@@ -69,7 +69,7 @@ case object clusterSequences extends Bundle(mg7BlastResults) { bundle =>
   /* This is the key method for the clustring pocedure.
      If we already have some clusters
 
-     * `{ b1 }
+     * `{ b1 }`
      * `{ a3, a2 }`
      * `{ b3, b4 }`
 
@@ -142,7 +142,7 @@ case object clusteringResults extends Bundle() {
 }
 
 
-/* ## Tests */
+/* ## A little test */
 case object ClusteringTestCtx {
 
   val hits: List[Set[ID]] = List(

--- a/src/test/scala/clusterSequences.scala
+++ b/src/test/scala/clusterSequences.scala
@@ -1,0 +1,87 @@
+package ohnosequences.db.rna16s.test
+
+import ohnosequences.db._, csvUtils._, collectionUtils._
+import ohnosequences.fastarious.fasta._
+import ohnosequences.statika._
+import ohnosequences.mg7._
+import ohnosequences.awstools.s3._
+import com.amazonaws.auth._
+import com.amazonaws.services.s3.transfer._
+import ohnosequences.blast.api._, outputFields._
+import com.github.tototoshi.csv._
+import better.files._
+
+
+
+case object clusterSequences extends Bundle(mg7BlastResults) { bundle =>
+
+  lazy val name: String = "clusters"
+
+  final lazy val s3: S3Folder = ohnosequences.db.rna16s.s3prefix / name /
+  final lazy val outputName: String = name + ".csv"
+
+
+  case object output {
+    lazy val file: File   = File(outputName).createIfNotExists()
+    lazy val s3: S3Object = bundle.s3 / outputName
+
+    lazy val csv = CSVWriter.open(this.file.toJava, append = true)(csvUtils.UnixCSVFormat)
+
+    def upload() = {
+
+      val transferManager = new TransferManager(new InstanceProfileCredentialsProvider())
+
+      transferManager.upload(
+        this.s3.bucket, this.s3.key,
+        this.file.toJava
+      ).waitForCompletion
+
+      transferManager.shutdownNow()
+    }
+  }
+
+
+  // TODO: tailrec
+  def addPair(qseq: ID, others: Seq[ID], acc: List[Set[ID]]): List[Set[ID]] = {
+    acc match {
+      case Nil => List( others.toSet + qseq )
+      case h :: t =>
+        if (h.contains(qseq)) (h ++ others) :: t
+        else h :: addPair(qseq, others, t)
+    }
+  }
+
+  def clusters(correspondences: Iterator[(ID, Seq[ID])]): List[Set[ID]] =
+    correspondences.foldLeft(List[Set[ID]]()) {
+      case (acc: List[Set[ID]], (qseq: ID, others: Seq[ID])) =>
+        addPair(qseq, others, acc)
+    }
+
+  type BlastRow = csv.Row[mg7.parameters.blastOutRec.Keys]
+
+  def instructions: AnyInstructions = {
+
+    LazyTry {
+
+      val blastReader = csv.Reader(mg7.parameters.blastOutRec.keys)(mg7BlastResults.blastResult)
+
+      val correspondences: Iterator[(ID, Seq[ID])] = blastReader.rows
+        // grouping rows by the query sequence id
+        .contiguousGroupBy { _.select(qseqid) }
+        .map { case (qseq: ID, hits: Seq[BlastRow]) =>
+
+          qseq -> hits.map { _.select(sseqid) }
+        }
+
+      clusters(correspondences).foreach { ids => output.csv.writeRow(ids.toSeq) }
+
+    } -&-
+    LazyTry {
+      println("Uploading the results...")
+      output.upload()
+    } -&-
+    say(s"Clastered sequences uploaded to [${output.s3}]")
+
+  }
+
+}

--- a/src/test/scala/clusterSequences.scala
+++ b/src/test/scala/clusterSequences.scala
@@ -86,7 +86,7 @@ case object clusterSequences extends Bundle(mg7BlastResults) { bundle =>
     newCluster :: rest
   }
 
-  /* This method folds over the hits applyin `addCluster` */
+  /* This method folds over the hits applying `addCluster` */
   def clusters(correspondences: Iterator[Set[ID]]): List[Set[ID]] =
     correspondences.foldLeft(List[Set[ID]]()) {
       case (acc: List[Set[ID]], (ids: Set[ID])) =>

--- a/src/test/scala/clusterSequences.scala
+++ b/src/test/scala/clusterSequences.scala
@@ -85,6 +85,24 @@ case object clusterSequences extends Bundle(mg7BlastResults) { bundle =>
 
 }
 
+case object clusteringResults extends Bundle() {
+
+  lazy val s3location: S3Object = clusterSequences.output.s3
+  lazy val clusters: File = File(s3location.key).createIfNotExists()
+
+  def instructions: AnyInstructions = LazyTry {
+    val transferManager = new TransferManager(new InstanceProfileCredentialsProvider())
+
+    transferManager.download(
+      s3location.bucket, s3location.key,
+      clusters.toJava
+    ).waitForCompletion
+
+    transferManager.shutdownNow()
+  } -&-
+  say(s"Clusters downloaded to ${clusters}")
+}
+
 
 case object ClusteringTestCtx {
 

--- a/src/test/scala/compats.scala
+++ b/src/test/scala/compats.scala
@@ -14,7 +14,7 @@ case object compats {
     ohnosequences.generated.metadata.db_rna16s
   )
 
-  case object pick16SCandidates extends DefaultCompatible(ohnosequences.db.rna16s.test.pick16SCandidates, javaHeap = 80)
+  case object pick16SCandidates extends DefaultCompatible(ohnosequences.db.rna16s.test.pick16SCandidates, javaHeap = 10)
 
   case object dropRedundantAssignmentsAndGenerate extends DefaultCompatible(ohnosequences.db.rna16s.test.dropRedundantAssignmentsAndGenerate, javaHeap = 10)
   case object dropInconsistentAssignmentsAndGenerate extends DefaultCompatible(ohnosequences.db.rna16s.test.dropInconsistentAssignmentsAndGenerate, javaHeap = 10)

--- a/src/test/scala/compats.scala
+++ b/src/test/scala/compats.scala
@@ -14,8 +14,15 @@ case object compats {
     ohnosequences.generated.metadata.db_rna16s
   )
 
-  case object pick16SCandidates extends DefaultCompatible(ohnosequences.db.rna16s.test.pick16SCandidates, javaHeap = 50)
+  case object pick16SCandidates extends
+    DefaultCompatible(ohnosequences.db.rna16s.test.pick16SCandidates, javaHeap = 50)
 
-  case object dropRedundantAssignmentsAndGenerate extends DefaultCompatible(ohnosequences.db.rna16s.test.dropRedundantAssignmentsAndGenerate, javaHeap = 10)
-  case object dropInconsistentAssignmentsAndGenerate extends DefaultCompatible(ohnosequences.db.rna16s.test.dropInconsistentAssignmentsAndGenerate, javaHeap = 10)
+  case object dropRedundantAssignmentsAndGenerate extends
+    DefaultCompatible(ohnosequences.db.rna16s.test.dropRedundantAssignmentsAndGenerate, javaHeap = 10)
+
+  case object clusterSequences extends
+    DefaultCompatible(ohnosequences.db.rna16s.test.clusterSequences, javaHeap = 10)
+
+  case object dropInconsistentAssignmentsAndGenerate extends
+    DefaultCompatible(ohnosequences.db.rna16s.test.dropInconsistentAssignmentsAndGenerate, javaHeap = 10)
 }

--- a/src/test/scala/compats.scala
+++ b/src/test/scala/compats.scala
@@ -14,7 +14,7 @@ case object compats {
     ohnosequences.generated.metadata.db_rna16s
   )
 
-  case object pick16SCandidates extends DefaultCompatible(ohnosequences.db.rna16s.test.pick16SCandidates, javaHeap = 10)
+  case object pick16SCandidates extends DefaultCompatible(ohnosequences.db.rna16s.test.pick16SCandidates, javaHeap = 50)
 
   case object dropRedundantAssignmentsAndGenerate extends DefaultCompatible(ohnosequences.db.rna16s.test.dropRedundantAssignmentsAndGenerate, javaHeap = 10)
   case object dropInconsistentAssignmentsAndGenerate extends DefaultCompatible(ohnosequences.db.rna16s.test.dropInconsistentAssignmentsAndGenerate, javaHeap = 10)

--- a/src/test/scala/dropInconsistentAssignments.scala
+++ b/src/test/scala/dropInconsistentAssignments.scala
@@ -80,12 +80,10 @@ case object dropInconsistentAssignments extends FilterDataFrom(dropRedundantAssi
   deps = clusteringResults, ncbiTaxonomyBundle
 ) {
 
-  private lazy val taxonomyGraph = ncbiTaxonomyBundle.graph
-
-  // type BlastRow = csv.Row[mg7.parameters.blastOutRec.Keys]
+  lazy val taxonomyGraph = ncbiTaxonomyBundle.graph
 
   /* Mapping of sequence IDs to the list of their taxonomic assignments */
-  private lazy val referenceMap: Map[ID, Seq[Taxon]] = source.table.csvReader.iterator
+  lazy val referenceMap: Map[ID, Seq[Taxon]] = source.table.csvReader.iterator
     .foldLeft(Map[ID, Seq[Taxon]]()) { (acc, row) =>
       acc.updated(
         row(0),
@@ -94,7 +92,7 @@ case object dropInconsistentAssignments extends FilterDataFrom(dropRedundantAssi
     }
 
   /* Mapping of sequence IDs to corresponding FASTA sequences */
-  private lazy val id2fasta: Map[ID, Fasta] = source.fasta.stream
+  lazy val id2fasta: Map[ID, Fasta] = source.fasta.stream
     .foldLeft(Map[ID, Fasta]()) { (acc, fasta) =>
       acc.updated(
         fasta.getV(header).id,
@@ -102,10 +100,10 @@ case object dropInconsistentAssignments extends FilterDataFrom(dropRedundantAssi
       )
     }
 
-  private def referenceTaxaFor(id: ID): Seq[Taxon] = referenceMap.get(id).getOrElse(Seq())
+  def referenceTaxaFor(id: ID): Seq[Taxon] = referenceMap.get(id).getOrElse(Seq())
 
   // TODO: this should be a piece of reusable code in MG7
-  private def getAccumulatedCounts(taxa: Seq[Taxon]): Map[Taxon, (Int, Seq[Taxon])] = {
+  def getAccumulatedCounts(taxa: Seq[Taxon]): Map[Taxon, (Int, Seq[Taxon])] = {
     // NOTE: this mutable map is used in getLineage for memoization of the results that we get from the DB
     val lineageMap: scala.collection.mutable.Map[Taxon, Taxa] = scala.collection.mutable.Map()
 
@@ -134,7 +132,7 @@ case object dropInconsistentAssignments extends FilterDataFrom(dropRedundantAssi
   val countsPercentageMinimum: Double = 42.75
 
   /* This predicate discards those taxons that are underrepresented by comparing its cumulative count to its ancestor's count */
-  private def predicate(countsMap: Map[Taxon, (Int, Seq[Taxon])], totalCount: Int): Taxon => Boolean = { taxon =>
+  def predicate(countsMap: Map[Taxon, (Int, Seq[Taxon])], totalCount: Int): Taxon => Boolean = { taxon =>
 
     countsMap.get(taxon).flatMap { case (_, lineage) =>
 

--- a/src/test/scala/dropInconsistentAssignments.scala
+++ b/src/test/scala/dropInconsistentAssignments.scala
@@ -183,7 +183,7 @@ case object dropInconsistentAssignmentsAndGenerate extends FilterAndGenerateBlas
 /* This bundle just downloads the output of the MG7 Blast step and merges the chunks */
 case object mg7BlastResults extends Bundle() {
 
-  lazy val s3location: S3Object = mg7.pipeline.outputS3Folder("", "blast") / "chunks" /
+  lazy val s3location: S3Folder = mg7.pipeline.outputS3Folder("", "blast") / "chunks" /
 
   lazy val blastChunks: File = File(s3location.key)
   lazy val blastResult: File = (blastChunks.parent / "blastResult.csv").createIfNotExists()
@@ -191,9 +191,9 @@ case object mg7BlastResults extends Bundle() {
   def instructions: AnyInstructions = LazyTry {
     val transferManager = new TransferManager(new InstanceProfileCredentialsProvider())
 
-    transferManager.download(
+    transferManager.downloadDirectory(
       s3location.bucket, s3location.key,
-      blastChunks.toJava
+      File(".").toJava
     ).waitForCompletion
 
     transferManager.shutdownNow()

--- a/src/test/scala/dropInconsistentAssignments.scala
+++ b/src/test/scala/dropInconsistentAssignments.scala
@@ -151,27 +151,27 @@ case object dropInconsistentAssignments extends FilterDataFrom(dropRedundantAssi
       .foreach { line =>
 
         val ids: Seq[ID] = line.split(',')
-        println(s"Processing cluster: ${ids.mkString(", ")}")
+        // println(s"Processing cluster: ${ids.mkString(", ")}")
 
         val taxa: Seq[Taxon] = ids.flatMap { id => referenceTaxaFor(id) }
-        println(s"Corresponding taxa: ${taxa.mkString(", ")}")
+        // println(s"Corresponding taxa: ${taxa.mkString(", ")}")
 
         val accumulatedCountsMap = getAccumulatedCounts(taxa)
-        println(s"Accumulated counts: ${accumulatedCountsMap.mkString(", ")}")
+        // println(s"Accumulated counts: ${accumulatedCountsMap.mkString(", ")}")
 
         val totalCount = taxa.length
-        println(s"Total count:        ${totalCount}")
+        // println(s"Total count:        ${totalCount}")
 
         // checking each assignment of the query sequence
         ids.foreach { id =>
 
-          print(s"\n  * id${id}")
+          // println(s"\n  * ${id}")
 
           val (acceptedTaxa, rejectedTaxa) = referenceTaxaFor(id).partition(
             predicate(accumulatedCountsMap, totalCount)
           )
-          println(s"    - accepted: ${acceptedTaxa}")
-          println(s"    - rejected: ${rejectedTaxa}")
+          // println(s"    - accepted: ${acceptedTaxa}")
+          // println(s"    - rejected: ${rejectedTaxa}")
 
           writeOutput(
             id,

--- a/src/test/scala/dropInconsistentAssignments.scala
+++ b/src/test/scala/dropInconsistentAssignments.scala
@@ -1,66 +1,11 @@
 /*
   # Drop inconsistent assignments
 
-  Here we want to drop "wrong", in the sense of *inconsistent*, assignments from our database. But, what is a wrong assignment? Let's see first an example:
+  Here we want to drop *inconsistent* assignments from our database. The idea here is to determine it based on sequences equivalence classes (1) (the we got from the previous clustering step) and their assignments taxonomic similarity (2).
 
-  ## Example of a wrong assignment
+  1. First we take the sequence clusters and for each of them (`C`) construct a common set of assignments (using the map we have from the previous steps): `Taxa(C)`.
 
-  Let's consider the following fragment of the taxonomic tree:
-
-  ```
-  tribeX
-  ├─ genusABC
-  │  ├─ ...
-  │  ...
-  │  └─ subgenusABC
-  │     ├─ speciesA
-  │     │  ├─ subspeciesA1
-  │     │  └─ subspeciesA2
-  │     ├─ speciesB1
-  │     ├─ speciesB2
-  │     └─ speciesC
-  ...
-  └─ ...
-     └─ ...
-        └─ speciesX
-  ```
-
-  And a sequence with following taxonomic assignments:
-
-  | ID   | Taxas                                |
-  |:-----|:-------------------------------------|
-  | seqA | subspeciesA1; subspeciesA2; speciesX |
-
-  In this case `speciesX` is *likely* a wrong assignment, because it's completely *unrelated* with the other, more specific assignments. If we will leave it in the database, the LCA of these nodes will be `tribeX`, instead of `speciesA`.
-
-  ## The definition of wrong
-
-  How could we detect something like the example before? if we have enough similar sequences in the database which are correctly assigned, we could
-
-  1. calculate (by sequence similarity) to what this sequence gets assigned using all the other sequences as a reference
-  2. see, for each of the original assignments, if they are "close" to the newly computed assignment; drop those which are "far" in the tree
-
-  Continuing with the example before, we run MG7, and BLAST tells us that `seqA` is *very* similar to `seqB` and `seqC` with the following assignments:
-
-  | ID   | Taxas                |
-  |:-----|:---------------------|
-  | seqB | speciesB1; speciesB2 |
-  | seqC | speciesC             |
-
-  We take their LCA which is `subgenusABC` and look at its parent: `genusABC`. Each of the `seqA`'s assignments has to be a descendant of `genusABC` and `speciesX`, obviously, is not, so we discard it:
-
-  | ID   | Taxas                      |
-  |:-----|:---------------------------|
-  | seqA | subspeciesA1; subspeciesA2 |
-
-  ## How it works
-
-  This step actually consists in two separate steps:
-
-  1. We run MG7 with input the output from the drop redundant assignments step, and as reference database the same but the sequence we are using as query.
-  2. For each sequence we check the relation of its assignments with the corresponding LCA that we've got from MG7. If some assignment is too far away from the LCA in the taxonomic tree, it is discarded. After this step the BLAST database is generated again.
-
-  Almost all `99.8%` of the sequences from the drop redundant assignments step pass  this filter, because it's mostly about filtering out *wrong* assignments and there are not many sequences that get all assignments discarded.
+  2. Then we consider each assignment `T` (from the old map) and decide wheter to drop it or to keep by comparing _its parent's_ cumulative count `Count(Parent(T))` with the total count (which is the size of `Taxa(C)`). If it's over some fixed threshold, we keep it, otherwise drop.
 */
 package ohnosequences.db.rna16s.test
 
@@ -102,16 +47,18 @@ case object dropInconsistentAssignments extends FilterDataFrom(dropRedundantAssi
 
   def referenceTaxaFor(id: ID): Seq[Taxon] = referenceMap.get(id).getOrElse(Seq())
 
+  /* This method for a given sequence of taxons (with repeats) returns their cumulative counts and lineages */
   // TODO: this should be a piece of reusable code in MG7
   def getAccumulatedCounts(taxa: Seq[Taxon]): Map[Taxon, (Int, Seq[Taxon])] = {
     // NOTE: this mutable map is used in getLineage for memoization of the results that we get from the DB
-    val lineageMap: scala.collection.mutable.Map[Taxon, Taxa] = scala.collection.mutable.Map()
+    val cacheMap: scala.collection.mutable.Map[Taxon, Taxa] = scala.collection.mutable.Map()
 
-    def getLineage(id: Taxon): Taxa = lineageMap.get(id).getOrElse {
+    /* This method looks up the lineage in the cache or queries the DB and updates the cache */
+    def getLineage(id: Taxon): Taxa = cacheMap.get(id).getOrElse {
       val lineage = taxonomyGraph.getTaxon(id)
         .map{ _.ancestors }.getOrElse( Seq() )
         .map{ _.id }
-      lineageMap.update(id, lineage)
+      cacheMap.update(id, lineage)
       lineage
     }
 
@@ -123,24 +70,24 @@ case object dropInconsistentAssignments extends FilterDataFrom(dropRedundantAssi
     accumulatedMap
   }
 
-  /* This constant determines how many levels up from the considered node will be the ancestor that we want to take for comparing their cumulative counts */
+  /* This threshold determines minimum percentage of the taxon's parent's count compared to the total count */
   // FIXME: this constant needs a review
-  val ancestorLevel: Int = 1 // i.e. direct parent by default
+  val countsPercentageMinimum: Double = 42.75 // % minimum
 
-  /* This threshold determines minimum percentage of the cumulative count of the considered taxon from its ancestor's count */
-  // FIXME: this constant needs a review
-  val countsPercentageMinimum: Double = 42.75
-
-  /* This predicate discards those taxons that are underrepresented by comparing its cumulative count to its ancestor's count */
+  /* This predicate determines whether to drop the taxon or to keep it */
   def predicate(countsMap: Map[Taxon, (Int, Seq[Taxon])], totalCount: Int): Taxon => Boolean = { taxon =>
 
+    /* First we find `taxon` in the `countsMap` to get its lineage */
     countsMap.get(taxon).flatMap { case (_, lineage) =>
 
-      val ancestorOpt = lineage.drop(ancestorLevel).headOption
+      /* and take its direct parent */
+      val ancestorOpt = lineage.drop(1).headOption
 
+      /* then we find out its count */
       ancestorOpt.flatMap(countsMap.get).map { case (ancestorCount, _) =>
 
-        ((ancestorCount: Double) / totalCount * 100) >= countsPercentageMinimum
+        /* and compare it with the total: it has to be more than `countsPercentageMinimum`% for `taxon` to pass */
+        ((ancestorCount: Double) / totalCount) >= (countsPercentageMinimum / 100)
       }
     }.getOrElse(false)
   }
@@ -150,19 +97,22 @@ case object dropInconsistentAssignments extends FilterDataFrom(dropRedundantAssi
     clusteringResults.clusters.lines
       .foreach { line =>
 
+        /* Sequence IDs of the cluster */
         val ids: Seq[ID] = line.split(',')
         // println(s"Processing cluster: ${ids.mkString(", ")}")
 
+        /* Corresponding taxa (to all sequence in the cluster together) */
         val taxa: Seq[Taxon] = ids.flatMap { id => referenceTaxaFor(id) }
         // println(s"Corresponding taxa: ${taxa.mkString(", ")}")
 
-        val accumulatedCountsMap = getAccumulatedCounts(taxa)
+        /* Counts (and lineages) for the taxa */
+        val accumulatedCountsMap: Map[Taxon, (Int, Seq[Taxon])] = getAccumulatedCounts(taxa)
         // println(s"Accumulated counts: ${accumulatedCountsMap.mkString(", ")}")
 
         val totalCount = taxa.length
         // println(s"Total count:        ${totalCount}")
 
-        // checking each assignment of the query sequence
+        /* Checking each assignment of the query sequence */
         ids.foreach { id =>
 
           // println(s"\n  * ${id}")
@@ -181,7 +131,6 @@ case object dropInconsistentAssignments extends FilterDataFrom(dropRedundantAssi
           )
         }
       }
-
   }
 
 }

--- a/src/test/scala/dropInconsistentAssignments.scala
+++ b/src/test/scala/dropInconsistentAssignments.scala
@@ -71,7 +71,7 @@ case class inconsistentAssignmentsFilter(
 
     countsMap.get(taxon)
       /* First we find `taxon`'s ancestor ID (2 levels up) */
-      .flatMap { case (_, lineage) => lineage.reverse.drop(2).headOption }
+      .flatMap { case (_, lineage) => lineage.reverse.drop(3).headOption }
       /* then we find out its count */
       .flatMap { ancestorId => countsMap.get(ancestorId) }
       /* and compare it with the total: it has to be more than `countsPercentageMinimum`% for `taxon` to pass */

--- a/src/test/scala/dropInconsistentAssignments.scala
+++ b/src/test/scala/dropInconsistentAssignments.scala
@@ -20,30 +20,22 @@ import com.amazonaws.services.s3.transfer._
 import ohnosequences.blast.api._, outputFields._
 import com.github.tototoshi.csv._
 import better.files._
+import com.bio4j.titan.model.ncbiTaxonomy.TitanNCBITaxonomyGraph
 
-case object dropInconsistentAssignments extends FilterDataFrom(dropRedundantAssignments)(
-  deps = clusteringResults, ncbiTaxonomyBundle
+case class inconsistentAssignmentsFilter(
+  val taxonomyGraph: TitanNCBITaxonomyGraph,
+  val assignmentsTable: File
 ) {
 
-  lazy val taxonomyGraph = ncbiTaxonomyBundle.graph
-
   /* Mapping of sequence IDs to the list of their taxonomic assignments */
-  lazy val referenceMap: Map[ID, Seq[Taxon]] = source.table.csvReader.iterator
-    .foldLeft(Map[ID, Seq[Taxon]]()) { (acc, row) =>
-      acc.updated(
-        row(0),
-        row(1).split(';').map(_.trim).toSeq
-      )
-    }
-
-  /* Mapping of sequence IDs to corresponding FASTA sequences */
-  lazy val id2fasta: Map[ID, Fasta] = source.fasta.stream
-    .foldLeft(Map[ID, Fasta]()) { (acc, fasta) =>
-      acc.updated(
-        fasta.getV(header).id,
-        fasta
-      )
-    }
+  lazy val referenceMap: Map[ID, Seq[Taxon]] =
+    CSVReader.open(assignmentsTable.toJava)(csvUtils.UnixCSVFormat).iterator
+      .foldLeft(Map[ID, Seq[Taxon]]()) { (acc, row) =>
+        acc.updated(
+          row(0),
+          row(1).split(';').map(_.trim).toSeq
+        )
+      }
 
   def referenceTaxaFor(id: ID): Seq[Taxon] = referenceMap.get(id).getOrElse(Seq())
 
@@ -77,62 +69,69 @@ case object dropInconsistentAssignments extends FilterDataFrom(dropRedundantAssi
   /* This predicate determines whether to drop the taxon or to keep it */
   def predicate(countsMap: Map[Taxon, (Int, Seq[Taxon])], totalCount: Int): Taxon => Boolean = { taxon =>
 
-    /* First we find `taxon` in the `countsMap` to get its lineage */
-    countsMap.get(taxon).flatMap { case (_, lineage) =>
-
-      /* and take its direct parent */
-      val ancestorOpt = lineage.drop(1).headOption
-
+    taxonomyGraph.getTaxon(taxon)
+      /* First we find `taxon`'s parent */
+      .flatMap { _.parent }
       /* then we find out its count */
-      ancestorOpt.flatMap(countsMap.get).map { case (ancestorCount, _) =>
-
-        /* and compare it with the total: it has to be more than `countsPercentageMinimum`% for `taxon` to pass */
-        ((ancestorCount: Double) / totalCount) >= (countsPercentageMinimum / 100)
+      .flatMap { parentNode => countsMap.get(parentNode.id) }
+      /* and compare it with the total: it has to be more than `countsPercentageMinimum`% for `taxon` to pass */
+      .map { case (parentCount, _) =>
+        ((parentCount: Double) / totalCount) >= (countsPercentageMinimum / 100)
       }
-    }.getOrElse(false)
+      .getOrElse(false)
   }
 
-  def filterData(): Unit = {
+  def partitionAssignments(cluster: Seq[ID]): Seq[(ID, Seq[Taxon], Seq[Taxon])] = {
 
-    clusteringResults.clusters.lines
-      .foreach { line =>
+    /* Corresponding taxa (to all sequence in the cluster together) */
+    val taxa: Seq[Taxon] = cluster.flatMap { id => referenceTaxaFor(id) }
+    val totalCount = taxa.length
 
-        /* Sequence IDs of the cluster */
-        val ids: Seq[ID] = line.split(',')
-        // println(s"Processing cluster: ${ids.mkString(", ")}")
+    /* Counts (and lineages) for the taxa */
+    val accumulatedCountsMap: Map[Taxon, (Int, Seq[Taxon])] = getAccumulatedCounts(taxa)
 
-        /* Corresponding taxa (to all sequence in the cluster together) */
-        val taxa: Seq[Taxon] = ids.flatMap { id => referenceTaxaFor(id) }
-        // println(s"Corresponding taxa: ${taxa.mkString(", ")}")
+    /* Checking each assignment of the query sequence */
+    cluster.map { id =>
 
-        /* Counts (and lineages) for the taxa */
-        val accumulatedCountsMap: Map[Taxon, (Int, Seq[Taxon])] = getAccumulatedCounts(taxa)
-        // println(s"Accumulated counts: ${accumulatedCountsMap.mkString(", ")}")
+      val (acceptedTaxa, rejectedTaxa) = referenceTaxaFor(id).partition(
+        predicate(accumulatedCountsMap, totalCount)
+      )
+      // println(s"* ${id}")
+      // if (rejectedTaxa.nonEmpty) {
+      //   println(s"    - accepted: ${acceptedTaxa.mkString(", ")}")
+      //   println(s"    - rejected: ${rejectedTaxa.mkString(", ")}")
+      // }
 
-        val totalCount = taxa.length
-        // println(s"Total count:        ${totalCount}")
-
-        /* Checking each assignment of the query sequence */
-        ids.foreach { id =>
-
-          // println(s"\n  * ${id}")
-
-          val (acceptedTaxa, rejectedTaxa) = referenceTaxaFor(id).partition(
-            predicate(accumulatedCountsMap, totalCount)
-          )
-          // println(s"    - accepted: ${acceptedTaxa}")
-          // println(s"    - rejected: ${rejectedTaxa}")
-
-          writeOutput(
-            id,
-            acceptedTaxa,
-            rejectedTaxa,
-            id2fasta(id)
-          )
-        }
-      }
+      (id, acceptedTaxa, rejectedTaxa)
+    }
   }
 
+}
+
+case object dropInconsistentAssignments extends FilterDataFrom(dropRedundantAssignments)(
+  deps = clusteringResults, ncbiTaxonomyBundle
+) {
+
+  /* Mapping of sequence IDs to corresponding FASTA sequences */
+  lazy val id2fasta: Map[ID, Fasta] = source.fasta.stream
+    .foldLeft(Map[ID, Fasta]()) { (acc, fasta) =>
+      acc.updated(
+        fasta.getV(header).id,
+        fasta
+      )
+    }
+
+  lazy val filter = inconsistentAssignmentsFilter(
+    ncbiTaxonomyBundle.graph,
+    source.table.file
+  )
+
+  def filterData(): Unit = clusteringResults.clusters.lines
+    .flatMap { line => filter.partitionAssignments( line.split(',') ) }
+    .foreach { case (id, accepted, rejected) =>
+
+      writeOutput(id, accepted, rejected, id2fasta(id))
+    }
 }
 
 case object dropInconsistentAssignmentsAndGenerate extends FilterAndGenerateBlastDB(
@@ -140,3 +139,33 @@ case object dropInconsistentAssignmentsAndGenerate extends FilterAndGenerateBlas
   ohnosequences.db.rna16s.dbType,
   ohnosequences.db.rna16s.test.dropInconsistentAssignments
 )
+
+
+/* This object provides some context for further testing in REPL */
+case object inconsistentAssignmentsTest {
+
+  import ohnosequencesBundles.statika._
+  import com.thinkaurelius.titan.core.TitanFactory
+  import com.bio4j.titan.util.DefaultTitanGraph
+  import org.apache.commons.configuration.Configuration
+
+  // You need to download some files for testing
+  case object local {
+
+    lazy val configuration: Configuration = DefaultBio4jTitanConfig(file"data/in/bio4j-taxonomy-titandb".toJava)
+
+    lazy val taxonomyGraph =
+      new TitanNCBITaxonomyGraph(
+        new DefaultTitanGraph(TitanFactory.open(configuration))
+      )
+
+    val assignmentsTable = file"data/in/table.csv"
+  }
+
+  // val testCluster: Seq[ID] = file"data/in/URS00008E71FD-cluster.csv".lines.next.split(',')
+
+  val filter = inconsistentAssignmentsFilter(
+    local.taxonomyGraph,
+    local.assignmentsTable
+  )
+}

--- a/src/test/scala/dropInconsistentAssignments.scala
+++ b/src/test/scala/dropInconsistentAssignments.scala
@@ -147,7 +147,8 @@ case object dropInconsistentAssignmentsAndGenerate extends FilterAndGenerateBlas
 /* This bundle just downloads the output of the MG7 run of the results of the drop redundant assignments step */
 case object mg7results extends Bundle() {
 
-  lazy val s3location: S3Object = referenceDBPipeline.outputS3Folder("merge") / "refdb.lca.csv"
+  // TODO: get results from the blast step
+  lazy val s3location: S3Object = mg7.pipeline.outputS3Folder("", "merge") / "refdb.lca.csv"
   lazy val lcaTable: File = File(s3location.key)
 
   def instructions: AnyInstructions = LazyTry {

--- a/src/test/scala/dropInconsistentAssignments.scala
+++ b/src/test/scala/dropInconsistentAssignments.scala
@@ -64,7 +64,7 @@ case class inconsistentAssignmentsFilter(
 
   /* This threshold determines minimum percentage of the taxon's parent's count compared to the total count */
   // FIXME: this constant needs a review
-  val countsPercentageMinimum: Double = 42.75 // % minimum
+  val countsPercentageMinimum: Double = 75.0 // % minimum
 
   /* This predicate determines whether to drop the taxon or to keep it */
   def predicate(countsMap: Map[Taxon, (Int, Seq[Taxon])], totalCount: Int): Taxon => Boolean = { taxon =>

--- a/src/test/scala/dropInconsistentAssignments.scala
+++ b/src/test/scala/dropInconsistentAssignments.scala
@@ -153,17 +153,27 @@ case object dropInconsistentAssignments extends FilterDataFrom(dropRedundantAssi
       .foreach { line =>
 
         val ids: Seq[ID] = line.split(',')
+        println(s"Processing cluster: ${ids.mkString(", ")}")
 
         val taxa: Seq[Taxon] = ids.flatMap { id => referenceTaxaFor(id) }
+        println(s"Corresponding taxa: ${taxa.mkString(", ")}")
+
         val accumulatedCountsMap = getAccumulatedCounts(taxa)
+        println(s"Accumulated counts: ${accumulatedCountsMap.mkString(", ")}")
+
         val totalCount = taxa.length
+        println(s"Total count:        ${totalCount}")
 
         // checking each assignment of the query sequence
         ids.foreach { id =>
 
+          print(s"\n  * id${id}")
+
           val (acceptedTaxa, rejectedTaxa) = referenceTaxaFor(id).partition(
             predicate(accumulatedCountsMap, totalCount)
           )
+          println(s"    - accepted: ${acceptedTaxa}")
+          println(s"    - rejected: ${rejectedTaxa}")
 
           writeOutput(
             id,

--- a/src/test/scala/dropInconsistentAssignments.scala
+++ b/src/test/scala/dropInconsistentAssignments.scala
@@ -69,14 +69,14 @@ case class inconsistentAssignmentsFilter(
   /* This predicate determines whether to drop the taxon or to keep it */
   def predicate(countsMap: Map[Taxon, (Int, Seq[Taxon])], totalCount: Int): Taxon => Boolean = { taxon =>
 
-    taxonomyGraph.getTaxon(taxon)
-      /* First we find `taxon`'s parent */
-      .flatMap { _.parent }
+    countsMap.get(taxon)
+      /* First we find `taxon`'s ancestor ID (2 levels up) */
+      .flatMap { case (_, lineage) => lineage.reverse.drop(2).headOption }
       /* then we find out its count */
-      .flatMap { parentNode => countsMap.get(parentNode.id) }
+      .flatMap { ancestorId => countsMap.get(ancestorId) }
       /* and compare it with the total: it has to be more than `countsPercentageMinimum`% for `taxon` to pass */
-      .map { case (parentCount, _) =>
-        ((parentCount: Double) / totalCount) >= (countsPercentageMinimum / 100)
+      .map { case (ancestorCount, _) =>
+        ((ancestorCount: Double) / totalCount) >= (countsPercentageMinimum / 100)
       }
       .getOrElse(false)
   }

--- a/src/test/scala/mg7pipeline.scala
+++ b/src/test/scala/mg7pipeline.scala
@@ -1,6 +1,6 @@
 package ohnosequences.db.rna16s.test
 
-import ohnosequences.mg7._, loquats._, dataflows._
+import ohnosequences.mg7._, loquats._
 import ohnosequences.datasets._, illumina._
 import ohnosequences.cosas._, types._, klists._
 import ohnosequences.loquat._, utils._
@@ -17,7 +17,7 @@ import com.amazonaws.auth._, profile._
 
 import better.files._
 
-case object referenceDBPipeline {
+case object mg7 {
 
   /* As the reference database we use the one generated from dropRedundantAssignments */
   case object rna16sRefDB extends ReferenceDB(
@@ -26,16 +26,7 @@ case object referenceDBPipeline {
     dropRedundantAssignments.output.table.s3
   )
 
-  /* As input we use the FASTA accepted by dropRedundantAssignments */
-  val splitInputs: Map[ID, S3Resource] = Map(
-    "refdb" -> S3Resource(ohnosequences.db.rna16s.test.dropRedundantAssignments.output.fasta.s3)
-  )
-
-  def outputS3Folder(step: String): S3Folder = ohnosequences.db.rna16s.s3prefix / "mg7" / step /
-
-  case object mg7parameters extends MG7Parameters(
-    (_, step) => outputS3Folder(step),
-    readsLength = bp250, // NOTE: this does not have any influence
+  case object parameters extends MG7Parameters(
     splitChunkSize = 100,
     splitInputFormat = FastaInput,
     blastCommand = blastn,
@@ -49,8 +40,7 @@ case object referenceDBPipeline {
       *[AnyDenotation]
     ).value,
     referenceDBs = Set(rna16sRefDB)
-  )
-  {
+  ) {
 
     /* The only basic thing we require is at least 99% **query** coverage. */
     override def blastFilter(row: csv.Row[BlastOutRecKeys]): Boolean =
@@ -59,89 +49,27 @@ case object referenceDBPipeline {
       ( row.select(outputFields.qseqid) != row.select(outputFields.sseqid) )
   }
 
-  lazy val dataflow = NoFlashDataflow(mg7parameters)(splitInputs)
-
-  /* This class is a default loquat configuration for this pipeline */
-  abstract class RefDBLoquatConfig(
-    val loquatName: String,
-    val dataMappings: List[AnyDataMapping],
-    val workersNumber: Int = 1
-  ) extends AnyLoquatConfig {
+  case object pipeline extends MG7Pipeline(parameters) {
 
     val metadata: AnyArtifactMetadata = ohnosequences.generated.metadata.db_rna16s
-
     // TODO: we should probably have a restricted role for this:
     val iamRoleName: String = "era7-projects"
     val logsBucketName: String = "era7-projects-loquats"
 
-    val defaultAMI = AmazonLinuxAMI(Ireland, HVM, InstanceStore)
-
-    val managerConfig: AnyManagerConfig = ManagerConfig(
-      InstanceSpecs(defaultAMI, m3.medium),
-      purchaseModel = Spot(maxPrice = Some(0.01))
+    /* As input we use the FASTA accepted by dropRedundantAssignments */
+    lazy val inputSamples: Map[ID, S3Resource] = Map(
+      "refdb" -> S3Resource(ohnosequences.db.rna16s.test.dropRedundantAssignments.output.fasta.s3)
     )
 
-    val workersConfig: AnyWorkersConfig = WorkersConfig(
-      instanceSpecs = InstanceSpecs(defaultAMI, m3.medium),
-      purchaseModel = Spot(maxPrice = Some(0.02)),
-      groupSize = AutoScalingGroupSize(0, workersNumber, workersNumber*2)
-    )
+    lazy val outputS3Folder: (SampleID, StepName) => S3Folder = { (_, stepName) =>
+      ohnosequences.db.rna16s.s3prefix / "mg7" / stepName /
+    }
 
-    val terminationConfig = TerminationConfig(
-      terminateAfterInitialDataMappings = true
-    )
+    val splitConfig  = SplitConfig(1)
+    val blastConfig  = BlastConfig(100)
+    // these steps are not needed:
+    val assignConfig = AssignConfig(10)
+    val mergeConfig  = MergeConfig(1)
+    val countConfig  = CountConfig(1)
   }
-
-  /*
-    ### mg7 steps
-
-    These objects define the mg7 pipeline steps. You need to run them in the order they are written here.
-
-    For running them, go to the scala console and run
-
-    ```
-    ohnosequences.db.rna16s.referenceDBPipeline.<name>Loquat.deploy(era7.defaults.<yourUser>)
-    ```
-  */
-
-  case object splitConfig extends RefDBLoquatConfig("split", dataflow.splitDataMappings)
-  case object splitLoquat extends Loquat(splitConfig, splitDataProcessing(mg7parameters))
-
-  case object blastConfig extends RefDBLoquatConfig("blast", dataflow.blastDataMappings, 100) {
-    // NOTE: we don't want to check input objects here because they are too many and
-    //   checking them one by one will take too long and likely fail
-    override val checkInputObjects = false
-
-    override val workersConfig: AnyWorkersConfig = WorkersConfig(
-      instanceSpecs = InstanceSpecs(defaultAMI, c3.large),
-      purchaseModel = Spot(maxPrice = Some(0.03)),
-      groupSize = AutoScalingGroupSize(0, workersNumber, workersNumber)
-    )
-  }
-  case object blastLoquat extends Loquat(blastConfig, blastDataProcessing(mg7parameters))
-
-
-  case object assignConfig extends RefDBLoquatConfig("assign", dataflow.assignDataMappings, 10) {
-    override val checkInputObjects = false
-
-    override lazy val amiEnv = amznAMIEnv(ami, javaHeap = 10)
-
-    override val workersConfig: AnyWorkersConfig = WorkersConfig(
-      instanceSpecs = InstanceSpecs(defaultAMI, m3.xlarge),
-      purchaseModel = Spot(maxPrice = Some(0.03)),
-      groupSize = AutoScalingGroupSize(0, workersNumber, workersNumber)
-    )
-  }
-  case object assignLoquat extends Loquat(assignConfig, assignDataProcessing(mg7parameters))
-
-  case object mergeConfig extends RefDBLoquatConfig("merge", dataflow.mergeDataMappings) {
-    override val skipEmptyResults = false
-
-    override val workersConfig: AnyWorkersConfig = WorkersConfig(
-      instanceSpecs = InstanceSpecs(defaultAMI, c3.large),
-      purchaseModel = Spot(maxPrice = Some(0.03)),
-      groupSize = AutoScalingGroupSize(0, workersNumber, workersNumber*2)
-    )
-  }
-  case object mergeLoquat extends Loquat(mergeConfig, mergeDataProcessing)
 }

--- a/src/test/scala/package.scala
+++ b/src/test/scala/package.scala
@@ -1,6 +1,12 @@
 package ohnosequences.db.rna16s
 
+import ohnosequences.fastarious.fasta._
+
 package object test {
+
+  type ID    = String
+  type Taxon = String
+  type Fasta = FASTA.Value
 
   // TODO: move it to db.rnacentral
   implicit class IteratorOps[V](val iterator: Iterator[V]) extends AnyVal {

--- a/src/test/scala/package.scala
+++ b/src/test/scala/package.scala
@@ -1,0 +1,36 @@
+package ohnosequences.db.rna16s
+
+package object test {
+
+  // TODO: move it to db.rnacentral
+  implicit class IteratorOps[V](val iterator: Iterator[V]) extends AnyVal {
+
+    /* Similar to the Stream's .groupBy, but assuming that groups are contiguous. Another difference is that it returns the key corresponding to each group. */
+    // NOTE: The original iterator should be discarded after calling this method
+    def contiguousGroupBy[K](getKey: V => K): Iterator[(K, Seq[V])] = new Iterator[(K, Seq[V])] {
+      /* The definition is very straightforward: we keep the `rest` of values and on each `.next()` call bite off the longest prefix with the same key */
+
+      /* Buffered iterator allows to look ahead without removing the next element */
+      private val rest: BufferedIterator[V] = iterator.buffered
+
+      // NOTE: this is so simple, because of the contiguous grouping assumpltion
+      def hasNext: Boolean = rest.hasNext
+
+      def next(): (K, Seq[V]) = {
+        val key = getKey(rest.head)
+
+        key -> groupOf(key)
+      }
+
+      @annotation.tailrec
+      private def groupOf_rec(key: K, acc: Seq[V]): Seq[V] = {
+        if ( rest.hasNext && getKey(rest.head) == key )
+          groupOf_rec(key, rest.next() +: acc)
+        else acc
+      }
+
+      private def groupOf(key: K): Seq[V] = groupOf_rec(key, Seq())
+    }
+  }
+
+}

--- a/src/test/scala/pick16SCandidates.scala
+++ b/src/test/scala/pick16SCandidates.scala
@@ -104,42 +104,11 @@ case object pick16SCandidates extends FilterData(
     ( (seq.count(_ == 'N') / seq.length) <= 0.01 )
   }
 
-  // TODO: move it to db.rnacentral
-  implicit class IteratorOps[V](val iterator: Iterator[V]) extends AnyVal {
-
-    /* Similar to the Stream's .groupBy, but assuming that groups are contiguous. Another difference is that it returns the key corresponding to each group. */
-    // NOTE: The original iterator should be discarded after calling this method
-    def groupBy[K](getKey: V => K): Iterator[(K, Seq[V])] = new Iterator[(K, Seq[V])] {
-      /* The definition is very straightforward: we keep the `rest` of values and on each `.next()` call bite off the longest prefix with the same key */
-
-      /* Buffered iterator allows to look ahead without removing the next element */
-      private val rest: BufferedIterator[V] = iterator.buffered
-
-      // NOTE: this is so simple, because of the contiguous grouping assumpltion
-      def hasNext: Boolean = rest.hasNext
-
-      def next(): (K, Seq[V]) = {
-        val key = getKey(rest.head)
-
-        key -> groupOf(key)
-      }
-
-      @annotation.tailrec
-      private def groupOf_rec(key: K, acc: Seq[V]): Seq[V] = {
-        if ( rest.hasNext && getKey(rest.head) == key )
-          groupOf_rec(key, rest.next() +: acc)
-        else acc
-      }
-
-      private def groupOf(key: K): Seq[V] = groupOf_rec(key, Seq())
-    }
-  }
-
   // bundle to generate the DB (see the runBundles file in tests)
   def filterData(): Unit = {
 
     val groupedRows: Iterator[(String, Seq[Row])] =
-      source.table.tsvReader.iterator.groupBy { _.select(id) }
+      source.table.tsvReader.iterator.contiguousGroupBy { _.select(id) }
 
     val fastas: Iterator[FASTA.Value] = source.fasta.stream.toIterator
 

--- a/src/test/scala/pick16SCandidates.scala
+++ b/src/test/scala/pick16SCandidates.scala
@@ -66,7 +66,7 @@ case object pick16SCandidates extends FilterData(
 
     Sequences that satisfy this predicate (on themselves together with their annotation) are included in the output of this step.
   */
-  private lazy val taxonomyGraph = ohnosequences.mg7.bio4j.taxonomyBundle.graph
+  private lazy val taxonomyGraph = ohnosequences.ncbitaxonomy.ncbiTaxonomyBundle.graph
 
   def rowPredicate(row: Row): Boolean = {
     val taxID = row.select(tax_id)

--- a/src/test/scala/runBundles.scala
+++ b/src/test/scala/runBundles.scala
@@ -29,7 +29,12 @@ case object rna16s {
   def pick16SCandidates(user: AWSUser): List[String] =
     launch(ohnosequences.db.rna16s.test.compats.pick16SCandidates, r3.x2large)(user)
 
-  def dropRedundantAssignmentsAndGenerate(user: AWSUser): List[String] = launch(ohnosequences.db.rna16s.test.compats.dropRedundantAssignmentsAndGenerate, r3.large)(user)
+  def dropRedundantAssignmentsAndGenerate(user: AWSUser): List[String] =
+    launch(ohnosequences.db.rna16s.test.compats.dropRedundantAssignmentsAndGenerate, r3.large)(user)
 
-  def dropInconsistentAssignmentsAndGenerate(user: AWSUser): List[String] = launch(ohnosequences.db.rna16s.test.compats.dropInconsistentAssignmentsAndGenerate, r3.large)(user)
+  def clusterSequences(user: AWSUser): List[String] =
+    launch(ohnosequences.db.rna16s.test.compats.clusterSequences, r3.large)(user)
+
+  def dropInconsistentAssignmentsAndGenerate(user: AWSUser): List[String] =
+    launch(ohnosequences.db.rna16s.test.compats.dropInconsistentAssignmentsAndGenerate, r3.large)(user)
 }

--- a/src/test/scala/runBundles.scala
+++ b/src/test/scala/runBundles.scala
@@ -27,7 +27,7 @@ case object rna16s {
   }
 
   def pick16SCandidates(user: AWSUser): List[String] =
-    launch(ohnosequences.db.rna16s.test.compats.pick16SCandidates, r3.x4large)(user)
+    launch(ohnosequences.db.rna16s.test.compats.pick16SCandidates, r3.large)(user)
 
   def dropRedundantAssignmentsAndGenerate(user: AWSUser): List[String] = launch(ohnosequences.db.rna16s.test.compats.dropRedundantAssignmentsAndGenerate, r3.large)(user)
 

--- a/src/test/scala/runBundles.scala
+++ b/src/test/scala/runBundles.scala
@@ -27,7 +27,7 @@ case object rna16s {
   }
 
   def pick16SCandidates(user: AWSUser): List[String] =
-    launch(ohnosequences.db.rna16s.test.compats.pick16SCandidates, r3.large)(user)
+    launch(ohnosequences.db.rna16s.test.compats.pick16SCandidates, r3.x2large)(user)
 
   def dropRedundantAssignmentsAndGenerate(user: AWSUser): List[String] = launch(ohnosequences.db.rna16s.test.compats.dropRedundantAssignmentsAndGenerate, r3.large)(user)
 


### PR DESCRIPTION
1. From the `mg7pipeline` run only `split` and `blast` steps
2. Add new filter which will
   - retrieve the output of blast and merge/group it per sequence
   - for each sequence review its assignments in the context of the taxas corresponding to the blast hits:
     - go up the assignment's lineage for a fixed number of layers/ranks
     - check accumulated count and compare it with the total number of the hits (assignments?)
     - discard it if it's lower than a given threshold

@eparejatobes @rtobes review this please and add any details 
