### PR TITLE
Keeping descendants of coherent assignments from the same cluster

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ generateStatikaMetadataIn(Compile)
 // NOTE should be reestablished
 wartremoverErrors in (Test, compile) := Seq()
 
-mergeStrategy in assembly ~= { old => {
+assemblyMergeStrategy in assembly ~= { old => {
     case "log4j.properties"                       => MergeStrategy.filterDistinctLines
     case PathList("org", "apache", "commons", _*) => MergeStrategy.first
     case x                                        => old(x)

--- a/src/test/scala/dropInconsistentAssignments.scala
+++ b/src/test/scala/dropInconsistentAssignments.scala
@@ -97,20 +97,17 @@ case class inconsistentAssignmentsFilter(
         predicate(accumulatedCountsMap, totalCount)
       )
 
-      /* Collecting all ancestor of accepted taxa together */
-      val ancestors: Set[Taxon] = acceptedTaxa.flatMap { taxon =>
-
+      /* Among previously rejected we pick those that are descendants of the accepted taxa and keep them too */
+      val (acceptedDescendants, rejectedRest) = rejectedTaxa.partition { taxon =>
         accumulatedCountsMap.get(taxon)
           .map { case (_, lineage) =>
-            lineage.toSet
+            // at least one ancestor is among accepted ones:
+            (lineage.toSet intersect acceptedTaxa).nonEmpty
           }
-          .getOrElse(Set())
+          .getOrElse(false)
       }
 
-      /* Among previously rejected we pick those that are ancestors of the accepted taxa and keep them too */
-      val (acceptedAncestors, rejectedUnrelated) = rejectedTaxa.partition(ancestors.contains)
-
-      (id, acceptedTaxa ++ acceptedAncestors, rejectedUnrelated)
+      (id, acceptedTaxa ++ acceptedDescendants, rejectedRest)
     }
   }
 


### PR DESCRIPTION
In our equivalence class consistency checks, we could have two assignments t1, t2 _in the same equivalence class_ for which

1. t2 is a descendant of t1
2. t1 is dropped, t2 is kept
   
Should t1 be kept? I vote yes.
