### PR TITLE
Release 0.4.0

### DIFF
--- a/src/main/scala/io.scala
+++ b/src/main/scala/io.scala
@@ -36,8 +36,8 @@ case object io {
       (rnaID, taxIDs)
     }.toMap
 
-  /** Receives a [[Mappings]] structure and produces a serialized 
-    * writable output 
+  /** Receives a [[Mappings]] structure and produces a serialized
+    * writable output
     */
   def serializeMappings(mappings: Mappings): Lines =
     mappings.toIterator.map {


### PR DESCRIPTION
It was needed to add a change in the docs required by `nice-sbt-settings` to make the release.

Code released here:  
```
s3://releases.era7.com/ohnosequences/db-rna16s_2.12/4.0.0/
```
Databases released here: 
```
s3://resources.ohnosequences.com/ohnosequences/db/rna16s/unstable/{9.0, 10.0}
```

